### PR TITLE
Adds new resource ID proposal and function sig to all proposals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11557,7 +11557,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "rand 0.8.4",
  "static_assertions",
 ]

--- a/dkg-gadget/src/worker.rs
+++ b/dkg-gadget/src/worker.rs
@@ -909,6 +909,11 @@ where
 					data: finished_round.payload,
 					signature: finished_round.signature,
 				}),
+			DKGPayloadKey::ResourceIdUpdateProposal(_nonce) =>
+				Some(ProposalType::ResourceIdUpdateSigned {
+					data: finished_round.payload,
+					signature: finished_round.signature,
+				}),
 			// TODO: handle other key types
 		}
 	}

--- a/dkg-runtime-primitives/src/proposal.rs
+++ b/dkg-runtime-primitives/src/proposal.rs
@@ -16,6 +16,7 @@ pub enum DKGPayloadKey {
 	AnchorUpdateProposal(ProposalNonce),
 	TokenUpdateProposal(ProposalNonce),
 	WrappingFeeUpdateProposal(ProposalNonce),
+	ResourceIdUpdateProposal(ProposalNonce),
 }
 
 impl Hash for DKGPayloadKey {
@@ -38,6 +39,8 @@ pub enum ProposalType {
 	TokenUpdateSigned { data: Vec<u8>, signature: Vec<u8> },
 	WrappingFeeUpdate { data: Vec<u8> },
 	WrappingFeeUpdateSigned { data: Vec<u8>, signature: Vec<u8> },
+	ResourceIdUpdate { data: Vec<u8> },
+	ResourceIdUpdateSigned { data: Vec<u8>, signature: Vec<u8> },
 }
 
 impl ProposalType {
@@ -51,6 +54,8 @@ impl ProposalType {
 			ProposalType::TokenUpdateSigned { data, .. } => data.clone(),
 			ProposalType::WrappingFeeUpdate { data } => data.clone(),
 			ProposalType::WrappingFeeUpdateSigned { data, .. } => data.clone(),
+			ProposalType::ResourceIdUpdate { data } => data.clone(),
+			ProposalType::ResourceIdUpdateSigned { data, .. } => data.clone(),
 		}
 	}
 
@@ -64,6 +69,8 @@ impl ProposalType {
 			ProposalType::TokenUpdateSigned { signature, .. } => signature.clone(),
 			ProposalType::WrappingFeeUpdate { .. } => Vec::new(),
 			ProposalType::WrappingFeeUpdateSigned { signature, .. } => signature.clone(),
+			ProposalType::ResourceIdUpdate { .. } => Vec::new(),
+			ProposalType::ResourceIdUpdateSigned { signature, .. } => signature.clone(),
 		}
 	}
 }
@@ -74,7 +81,7 @@ pub trait ProposalHandlerTrait {
 		action: ProposalAction,
 	) -> frame_support::pallet_prelude::DispatchResult;
 
-	fn handle_single_parameter_signed_proposal(
+	fn handle_signed_proposal(
 		prop: ProposalType,
 		payload_key: DKGPayloadKey,
 	) -> frame_support::pallet_prelude::DispatchResult;
@@ -92,6 +99,10 @@ pub trait ProposalHandlerTrait {
 	) -> frame_support::pallet_prelude::DispatchResult;
 
 	fn handle_wrapping_fee_update_signed_proposal(
+		prop: ProposalType,
+	) -> frame_support::pallet_prelude::DispatchResult;
+
+	fn handle_resource_id_update_signed_proposal(
 		prop: ProposalType,
 	) -> frame_support::pallet_prelude::DispatchResult;
 }

--- a/pallets/dkg-proposal-handler/src/lib.rs
+++ b/pallets/dkg-proposal-handler/src/lib.rs
@@ -684,7 +684,7 @@ impl<T: Config> Pallet<T> {
 	fn decode_chain_id_nonce_from_proposal<const N: usize>(
 		data: &[u8],
 	) -> Result<(T::ChainId, ProposalNonce), Error<T>> {
-		// check if the data length is 118 bytes [
+		// check if the data length is (86 + N) bytes [
 		// 	handler_address_0x_prefixed(22),
 		// 	chain_id(32),
 		// 	nonce(32),

--- a/pallets/dkg-proposal-handler/src/lib.rs
+++ b/pallets/dkg-proposal-handler/src/lib.rs
@@ -688,7 +688,7 @@ impl<T: Config> Pallet<T> {
 		// 	handler_address_0x_prefixed(22),
 		// 	chain_id(32),
 		// 	nonce(32),
-		//  function_sig(4),
+		//  (function_sig(4) + parameters_length()) -> N,
 		// 	parameter(N)
 		// ]
 		if data.len() != 22 + 32 + 32 + N {

--- a/pallets/dkg-proposal-handler/src/lib.rs
+++ b/pallets/dkg-proposal-handler/src/lib.rs
@@ -177,6 +177,8 @@ pub mod pallet {
 						Self::handle_token_update_signed_proposal(prop.clone())?,
 					ProposalType::WrappingFeeUpdateSigned { .. } =>
 						Self::handle_wrapping_fee_update_signed_proposal(prop.clone())?,
+					ProposalType::ResourceIdUpdateSigned { .. } =>
+						Self::handle_resource_id_update_signed_proposal(prop.clone())?,
 					_ => Err(Error::<T>::ProposalSignatureInvalid)?,
 				}
 			}
@@ -216,7 +218,16 @@ pub mod pallet {
 					);
 					Ok(().into())
 				},
-				_ => return Err(Error::<T>::ProposalFormatInvalid)?,
+				ProposalType::ResourceIdUpdate { ref data } => {
+					let (chain_id, nonce) = Self::decode_resource_id_update_proposal(&data)?;
+					UnsignedProposalQueue::<T>::insert(
+						chain_id,
+						DKGPayloadKey::ResourceIdUpdateProposal(nonce),
+						prop.clone(),
+					);
+					Ok(().into())
+				},
+				_ => Err(Error::<T>::ProposalFormatInvalid)?,
 			}
 		}
 	}
@@ -224,6 +235,8 @@ pub mod pallet {
 
 impl<T: Config> ProposalHandlerTrait for Pallet<T> {
 	fn handle_unsigned_proposal(proposal: Vec<u8>, _action: ProposalAction) -> DispatchResult {
+		#[cfg(feature = "std")]
+		println!("handle_unsigned_proposal: {}", proposal.len());
 		if let Ok(eth_transaction) = TransactionV2::decode(&mut &proposal[..]) {
 			ensure!(
 				Self::validate_ethereum_tx(&eth_transaction),
@@ -289,33 +302,42 @@ impl<T: Config> ProposalHandlerTrait for Pallet<T> {
 	}
 
 	fn handle_anchor_update_signed_proposal(prop: ProposalType) -> DispatchResult {
-		Self::handle_single_parameter_signed_proposal(
+		Self::handle_signed_proposal(
 			prop,
 			DKGPayloadKey::AnchorUpdateProposal(0u64),
 		)
 	}
 
 	fn handle_token_update_signed_proposal(prop: ProposalType) -> DispatchResult {
-		Self::handle_single_parameter_signed_proposal(
+		Self::handle_signed_proposal(
 			prop,
 			DKGPayloadKey::TokenUpdateProposal(0u64),
 		)
 	}
 
 	fn handle_wrapping_fee_update_signed_proposal(prop: ProposalType) -> DispatchResult {
-		Self::handle_single_parameter_signed_proposal(
+		Self::handle_signed_proposal(
 			prop,
 			DKGPayloadKey::WrappingFeeUpdateProposal(0),
 		)
 	}
 
-	fn handle_single_parameter_signed_proposal(
+	fn handle_resource_id_update_signed_proposal(
+		prop: ProposalType,
+	) -> frame_support::pallet_prelude::DispatchResult {
+		Self::handle_signed_proposal(
+			prop,
+			DKGPayloadKey::ResourceIdUpdateProposal(0),
+		)
+    }
+	
+	fn handle_signed_proposal(
 		prop: ProposalType,
 		payload_key_type: DKGPayloadKey,
 	) -> DispatchResult {
 		let data = prop.data();
 		let signature = prop.signature();
-		if let Ok((chain_id, nonce)) = Self::decode_single_parameter_proposal::<32>(&data) {
+		if let Ok((chain_id, nonce)) = Self::decode_chain_id_nonce_from_proposal::<32>(&data) {
 			// log the chain id and nonce
 			frame_support::log::debug!(
 				target: "dkg_proposal_handler",
@@ -325,11 +347,10 @@ impl<T: Config> ProposalHandlerTrait for Pallet<T> {
 			);
 
 			let payload_key = match payload_key_type {
-				DKGPayloadKey::AnchorUpdateProposal(_) =>
-					DKGPayloadKey::AnchorUpdateProposal(nonce),
+				DKGPayloadKey::AnchorUpdateProposal(_) => DKGPayloadKey::AnchorUpdateProposal(nonce),
 				DKGPayloadKey::TokenUpdateProposal(_) => DKGPayloadKey::TokenUpdateProposal(nonce),
-				DKGPayloadKey::WrappingFeeUpdateProposal(_) =>
-					DKGPayloadKey::WrappingFeeUpdateProposal(nonce),
+				DKGPayloadKey::WrappingFeeUpdateProposal(_) => DKGPayloadKey::WrappingFeeUpdateProposal(nonce),
+				DKGPayloadKey::ResourceIdUpdateProposal(_) => DKGPayloadKey::ResourceIdUpdateProposal(nonce),
 				_ => return Err(Error::<T>::ProposalFormatInvalid)?,
 			};
 			ensure!(
@@ -375,39 +396,33 @@ impl<T: Config> Pallet<T> {
 			ProposalType::EVMSigned { data, .. } => {
 				if let Ok(eth_transaction) = TransactionV2::decode(&mut &data[..]) {
 					if let Ok((chain_id, nonce)) = Self::decode_evm_transaction(&eth_transaction) {
-						return !SignedProposals::<T>::contains_key(
-							chain_id,
-							DKGPayloadKey::EVMProposal(nonce),
-						)
+						return !SignedProposals::<T>::contains_key(chain_id, DKGPayloadKey::EVMProposal(nonce))
 					}
 				}
 
 				false
 			},
 			ProposalType::AnchorUpdateSigned { data, .. } => {
-				if let Ok((chain_id, nonce)) = Self::decode_single_parameter_proposal::<32>(&data) {
-					return !SignedProposals::<T>::contains_key(
-						chain_id,
-						DKGPayloadKey::AnchorUpdateProposal(nonce),
-					)
+				if let Ok((chain_id, nonce)) = Self::decode_chain_id_nonce_from_proposal::<32>(&data) {
+					return !SignedProposals::<T>::contains_key(chain_id, DKGPayloadKey::AnchorUpdateProposal(nonce))
 				}
 				false
 			},
 			ProposalType::TokenUpdateSigned { data, .. } => {
-				if let Ok((chain_id, nonce)) = Self::decode_single_parameter_proposal::<32>(&data) {
-					return !SignedProposals::<T>::contains_key(
-						chain_id,
-						DKGPayloadKey::TokenUpdateProposal(nonce),
-					)
+				if let Ok((chain_id, nonce)) = Self::decode_chain_id_nonce_from_proposal::<32>(&data) {
+					return !SignedProposals::<T>::contains_key(chain_id, DKGPayloadKey::TokenUpdateProposal(nonce))
 				}
 				false
 			},
 			ProposalType::WrappingFeeUpdateSigned { data, .. } => {
-				if let Ok((chain_id, nonce)) = Self::decode_single_parameter_proposal::<32>(&data) {
-					return !SignedProposals::<T>::contains_key(
-						chain_id,
-						DKGPayloadKey::WrappingFeeUpdateProposal(nonce),
-					)
+				if let Ok((chain_id, nonce)) = Self::decode_chain_id_nonce_from_proposal::<32>(&data) {
+					return !SignedProposals::<T>::contains_key(chain_id, DKGPayloadKey::WrappingFeeUpdateProposal(nonce))
+				}
+				false
+			},
+			ProposalType::ResourceIdUpdateSigned { data, .. } => {
+				if let Ok((chain_id, nonce)) = Self::decode_chain_id_nonce_from_proposal::<32>(&data) {
+					return !SignedProposals::<T>::contains_key(chain_id, DKGPayloadKey::ResourceIdUpdateProposal(nonce))
 				}
 				false
 			},
@@ -616,9 +631,11 @@ impl<T: Config> Pallet<T> {
 			data,
 			data.len(),
 		);
-
-		// parameter is a address / bytes32 (32 byte element for extra room)
-		Self::decode_single_parameter_proposal::<32>(data)
+		#[cfg(feature = "std")]
+		println!("🕸️ Decoding anchor update: {:?} ({} bytes)", data, data.len());
+		// function signature + 2 parameters: (target_chain_id, merkle_root)
+		// 4 + 32 + 32 = 68 bytes
+		Self::decode_chain_id_nonce_from_proposal::<68>(data)
 	}
 
 	fn decode_token_update_proposal(data: &[u8]) -> Result<(T::ChainId, ProposalNonce), Error<T>> {
@@ -629,8 +646,9 @@ impl<T: Config> Pallet<T> {
 			data.len(),
 		);
 
-		// parameter is a address / bytes32 (32 byte element for extra room)
-		Self::decode_single_parameter_proposal::<32>(data)
+		// function signature + 1 parameters: (address token as bytes32)
+		// 4 + 32 = 36 bytes
+		Self::decode_chain_id_nonce_from_proposal::<36>(data)
 	}
 
 	fn decode_wrapping_fee_update_proposal(
@@ -643,17 +661,34 @@ impl<T: Config> Pallet<T> {
 			data.len(),
 		);
 
-		// parameter is a uint256 / bytes32 (32 byte element)
-		Self::decode_single_parameter_proposal::<32>(data)
+		// function signature + 1 parameters: (uint256 fee)
+		// 4 + 32 = 36 bytes
+		Self::decode_chain_id_nonce_from_proposal::<36>(data)
 	}
 
-	fn decode_single_parameter_proposal<const N: usize>(
+	fn decode_resource_id_update_proposal(
+		data: &[u8],
+	) -> Result<(T::ChainId, ProposalNonce), Error<T>> {
+		frame_support::log::debug!(
+			target: "dkg_proposal_handler",
+			"🕸️ Decoding resource id update: {:?} ({} bytes)",
+			data,
+			data.len(),
+		);
+
+		// function signature + 3 parameters: (bytes32 resourceId, address handlerAddress, address executionContext)
+		// 4 + 32 + 32 + 32 = 100 bytes
+		Self::decode_chain_id_nonce_from_proposal::<100>(data)
+	}
+
+	fn decode_chain_id_nonce_from_proposal<const N: usize>(
 		data: &[u8],
 	) -> Result<(T::ChainId, ProposalNonce), Error<T>> {
 		// check if the data length is 118 bytes [
 		// 	handler_address_0x_prefixed(22),
 		// 	chain_id(32),
 		// 	nonce(32),
+		//  function_sig(4),
 		// 	parameter(N)
 		// ]
 		if data.len() != 22 + 32 + 32 + N {

--- a/pallets/dkg-proposal-handler/src/lib.rs
+++ b/pallets/dkg-proposal-handler/src/lib.rs
@@ -689,7 +689,6 @@ impl<T: Config> Pallet<T> {
 		// 	chain_id(32),
 		// 	nonce(32),
 		//  (function_sig(4) + parameters_length()) -> N,
-		// 	parameter(N)
 		// ]
 		if data.len() != 22 + 32 + 32 + N {
 			return Err(Error::<T>::ProposalFormatInvalid)?


### PR DESCRIPTION
# Overview
This adds the resource ID proposal #42 to the DKG as well as updates all proposal decoding to the new structure

## Non-anchor proposal types
- Single parameter proposals
    - `(execution_chain_id, nonce, functionSig, newToken)`
    - `(execution_chain_id, nonce, functionSig, newFee)`
- Double parameter proposals
    - `(execution_chain_id, nonce, functionSig, param1, param2)`
- Triple parameter proposals
    - Setting resource ID, handler, execution contexts
    - `(execution_chain_id, nonce, functionSig, resourceId, handlerAddress, executionContextAddress)`

# Caveats & Issues
We need to think more here as we need to be sure we prevent a single proposal from being able to update multiple bridges. The execution_chain and nonce actually doesn't solve replay issues when we have multiple bridges and plan to deploy new ones.

For example, if we sign `(1, 1, keccak256(setFee(uint)), tokenAddress)`, while we may be protected from executing this _again_ on the same contract, it doesn't seem like it prevents anyone from replaying this on a _different_ GovernedToken if the governor is the same as the DKG. 

The same likely holds for anchor update proposals across totally different anchors on the same chain. Say we sign, `(chain_id, latest_leaf_index, merkle_root)`. After calling `executeProposalWithSig` with this data, we can't call it again on this anchor. But, it appears that we can call it on any other anchor whose latest leaf index is less than `latest_leaf_index`.

## Potential solution
Since we use resource IDs as contract addresses + chain_ids in a single `bytes32`, we can include this in our proposals. Then for every proposal, we check the chain ID matches the executing chain's chain identifier and guarantee that proposals are then specific to a given contract instance.

CC @saiakilesh @shekohex 