### PR TITLE
Update Proposal Encoding

### DIFF
--- a/dkg-runtime-primitives/src/lib.rs
+++ b/dkg-runtime-primitives/src/lib.rs
@@ -212,7 +212,7 @@ sp_api::decl_runtime_apis! {
 		/// Get untrack interval for unsigned proposals
 		fn untrack_interval() -> N;
 		/// Get next nonce value for refresh proposal
-		fn refresh_nonce() -> u64;
+		fn refresh_nonce() -> u32;
 		/// Get the time to restart for the dkg keygen
 		fn time_to_restart() -> N;
 	}

--- a/dkg-runtime-primitives/src/proposal.rs
+++ b/dkg-runtime-primitives/src/proposal.rs
@@ -6,7 +6,8 @@ use sp_std::vec::Vec;
 pub const PROPOSAL_SIGNATURE_LENGTH: usize = 65;
 
 pub type ResourceId = [u8; 32];
-pub type ProposalNonce = u64;
+// Proposal Nonces (4 bytes)
+pub type ProposalNonce = u32;
 
 #[derive(Clone, Encode, Decode, scale_info::TypeInfo)]
 pub struct RefreshProposal {
@@ -36,7 +37,8 @@ impl Encode for ProposalHeader {
 		// resource_id contains the chain id already.
 		buf.extend_from_slice(&self.resource_id); // 32 bytes
 		buf.extend_from_slice(&self.function_sig); // 4 bytes
-		buf.extend_from_slice(&(self.nonce as u32).to_le_bytes()); // 4 bytes
+		// we encode it in big endian that is what EVM expect things to be.
+		buf.extend_from_slice(&self.nonce.to_be_bytes()); // 4 bytes
 		buf
 	}
 
@@ -67,7 +69,7 @@ impl Decode for ProposalHeader {
 		// the nonce is the last 4 bytes of the header (also considered as the first arg).
 		let mut nonce_bytes = [0u8; 4];
 		nonce_bytes.copy_from_slice(&data[36..40]);
-		let nonce = u32::from_le_bytes(nonce_bytes);
+		let nonce = u32::from_be_bytes(nonce_bytes);
 		let header = ProposalHeader {
 			resource_id,
 			chain_id,

--- a/dkg-runtime-primitives/src/proposal.rs
+++ b/dkg-runtime-primitives/src/proposal.rs
@@ -37,7 +37,7 @@ impl Encode for ProposalHeader {
 		// resource_id contains the chain id already.
 		buf.extend_from_slice(&self.resource_id); // 32 bytes
 		buf.extend_from_slice(&self.function_sig); // 4 bytes
-		// we encode it in big endian that is what EVM expect things to be.
+										   // we encode it in big endian that is what EVM expect things to be.
 		buf.extend_from_slice(&self.nonce.to_be_bytes()); // 4 bytes
 		buf
 	}
@@ -224,7 +224,7 @@ mod tests {
 	fn proposal_encode_decode() {
 		let mut proposal_data = Vec::with_capacity(80);
 		let chain_id = 5002u32;
-		let nonce = 0xffu64;
+		let nonce = 0xffu32;
 		let resource_id = {
 			let mut r = [0u8; 32];
 			r[28..32].copy_from_slice(&chain_id.to_be_bytes());
@@ -236,8 +236,8 @@ mod tests {
 		let last_leaf_index = nonce as u32;
 		let merkle_root = [0xeeu8; 32];
 		proposal_header.encode_to(&mut proposal_data);
-		proposal_data.extend_from_slice(&src_id.to_le_bytes());
-		proposal_data.extend_from_slice(&last_leaf_index.to_le_bytes());
+		proposal_data.extend_from_slice(&src_id.to_be_bytes());
+		proposal_data.extend_from_slice(&last_leaf_index.to_be_bytes());
 		proposal_data.extend_from_slice(&merkle_root);
 		assert_eq!(proposal_data.len(), 80);
 		let hex = hex::encode(&proposal_data);

--- a/dkg-runtime-primitives/src/proposal.rs
+++ b/dkg-runtime-primitives/src/proposal.rs
@@ -37,7 +37,7 @@ impl Encode for ProposalHeader {
 		// resource_id contains the chain id already.
 		buf.extend_from_slice(&self.resource_id); // 32 bytes
 		buf.extend_from_slice(&self.function_sig); // 4 bytes
-										   // we encode it in big endian that is what EVM expect things to be.
+		// we encode it in big endian that is what EVM expect things to be.
 		buf.extend_from_slice(&self.nonce.to_be_bytes()); // 4 bytes
 		buf
 	}

--- a/pallets/dkg-metadata/src/lib.rs
+++ b/pallets/dkg-metadata/src/lib.rs
@@ -250,7 +250,7 @@ pub mod pallet {
 	/// Nonce value for next refresh proposal
 	#[pallet::storage]
 	#[pallet::getter(fn refresh_nonce)]
-	pub type RefreshNonce<T: Config> = StorageValue<_, u64, ValueQuery>;
+	pub type RefreshNonce<T: Config> = StorageValue<_, u32, ValueQuery>;
 
 	/// Signature of the DKG public key for the next session
 	#[pallet::storage]
@@ -634,7 +634,7 @@ impl<T: Config> Pallet<T> {
 					signature.clone(),
 				));
 				// Increase nonce value
-				RefreshNonce::<T>::put(refresh_nonce + 1u64);
+				RefreshNonce::<T>::put(refresh_nonce + 1u32);
 				Self::deposit_event(Event::NextPublicKeySignatureSubmitted {
 					pub_key_sig: signature.clone(),
 				});

--- a/pallets/dkg-proposal-handler/src/lib.rs
+++ b/pallets/dkg-proposal-handler/src/lib.rs
@@ -336,19 +336,19 @@ impl<T: Config> ProposalHandlerTrait for Pallet<T> {
 	}
 
 	fn handle_anchor_update_signed_proposal(prop: ProposalType) -> DispatchResult {
-		Self::handle_signed_proposal(prop, DKGPayloadKey::AnchorUpdateProposal(0u64))
+		Self::handle_signed_proposal(prop, DKGPayloadKey::AnchorUpdateProposal(0))
 	}
 
 	fn handle_token_add_signed_proposal(
 		prop: ProposalType,
 	) -> frame_support::pallet_prelude::DispatchResult {
-		Self::handle_signed_proposal(prop, DKGPayloadKey::TokenAddProposal(0u64))
+		Self::handle_signed_proposal(prop, DKGPayloadKey::TokenAddProposal(0))
 	}
 
 	fn handle_token_remove_signed_proposal(
 		prop: ProposalType,
 	) -> frame_support::pallet_prelude::DispatchResult {
-		Self::handle_signed_proposal(prop, DKGPayloadKey::TokenRemoveProposal(0u64))
+		Self::handle_signed_proposal(prop, DKGPayloadKey::TokenRemoveProposal(0))
 	}
 
 	fn handle_wrapping_fee_update_signed_proposal(prop: ProposalType) -> DispatchResult {
@@ -668,17 +668,17 @@ impl<T: Config> Pallet<T> {
 		let (chain_id, nonce) = match eth_transaction {
 			TransactionV2::Legacy(tx) => {
 				let chain_id: u64 = 0;
-				let nonce = tx.nonce.as_u64();
+				let nonce = tx.nonce.as_u32();
 				(chain_id, nonce)
 			},
 			TransactionV2::EIP2930(tx) => {
 				let chain_id: u64 = tx.chain_id;
-				let nonce = tx.nonce.as_u64();
+				let nonce = tx.nonce.as_u32();
 				(chain_id, nonce)
 			},
 			TransactionV2::EIP1559(tx) => {
 				let chain_id: u64 = tx.chain_id;
-				let nonce = tx.nonce.as_u64();
+				let nonce = tx.nonce.as_u32();
 				(chain_id, nonce)
 			},
 		};

--- a/pallets/dkg-proposal-handler/src/lib.rs
+++ b/pallets/dkg-proposal-handler/src/lib.rs
@@ -712,14 +712,17 @@ impl<T: Config> Pallet<T> {
 		let header = Self::decode_proposal_header(data)?;
 		let mut src_chain_id_bytes = [0u8; 4];
 		src_chain_id_bytes.copy_from_slice(&data[40..44]);
-		let src_chain_id = u32::from_le_bytes(src_chain_id_bytes);
+		let src_chain_id = u32::from_be_bytes(src_chain_id_bytes);
 		let mut latest_leaf_index_bytes = [0u8; 4];
 		latest_leaf_index_bytes.copy_from_slice(&data[44..48]);
-		let latest_leaf_index = u32::from_le_bytes(latest_leaf_index_bytes);
+		let latest_leaf_index = u32::from_be_bytes(latest_leaf_index_bytes);
 		let mut merkle_root_bytes = [0u8; 32];
 		merkle_root_bytes.copy_from_slice(&data[48..80]);
 		// 1. Should we check for the function signature?
 		// 2. Should we check for the chainId != srcChainId?
+		// TODO: do something with them here.
+		let _ = src_chain_id;
+		let _ = latest_leaf_index;
 		Ok(header)
 	}
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -7,7 +7,7 @@
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 use codec::{Decode, Encode};
-use dkg_runtime_primitives::{DKGPayloadKey, ProposalNonce, ProposalType};
+use dkg_runtime_primitives::{ChainId, DKGPayloadKey, ProposalNonce, ProposalType};
 use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
 use sp_runtime::{
@@ -19,7 +19,6 @@ use sp_runtime::{
 	transaction_validity::{TransactionSource, TransactionValidity},
 	ApplyExtrinsicResult, MultiSignature, SaturatedConversion,
 };
-use dkg_runtime_primitives::ChainId;
 
 use sp_std::prelude::*;
 #[cfg(feature = "std")]
@@ -811,7 +810,7 @@ impl_runtime_apis! {
 			dkg_runtime_primitives::UNTRACK_INTERVAL
 		}
 
-		fn refresh_nonce() -> u64 {
+		fn refresh_nonce() -> u32 {
 			DKG::refresh_nonce()
 		}
 

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -7,7 +7,9 @@
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 use codec::{Decode, Encode};
-use dkg_runtime_primitives::{mmr::MmrLeafVersion, DKGPayloadKey, ProposalNonce, ProposalType};
+use dkg_runtime_primitives::{
+	mmr::MmrLeafVersion, ChainId, DKGPayloadKey, ProposalNonce, ProposalType,
+};
 use frame_support::traits::{ConstU32, Everything, U128CurrencyToVote};
 use pallet_grandpa::{
 	fg_primitives, AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList,
@@ -28,7 +30,6 @@ use sp_runtime::{
 	transaction_validity::{TransactionPriority, TransactionSource, TransactionValidity},
 	ApplyExtrinsicResult, MultiSignature, SaturatedConversion,
 };
-use dkg_runtime_primitives::ChainId;
 
 use frame_system::EnsureRoot;
 use pallet_session::historical as pallet_session_historical;
@@ -844,7 +845,7 @@ impl_runtime_apis! {
 			dkg_runtime_primitives::UNTRACK_INTERVAL
 		}
 
-		fn refresh_nonce() -> u64 {
+		fn refresh_nonce() -> u32 {
 			DKG::refresh_nonce()
 		}
 


### PR DESCRIPTION
This one does two main things:

1. Update any encoding to be Big-Endian (that's what EVM expects)
2. Use nonces to be `u32` instead of `u64`.