### PR TITLE
Rotate keys on session + refresh tx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 
 # The cache for chain data in container
 .local
+tmp
 
 local-test
 

--- a/dkg-primitives/src/types.rs
+++ b/dkg-primitives/src/types.rs
@@ -152,3 +152,38 @@ pub enum DKGError {
 	CriticalError { reason: String },
 	GenericError { reason: String }, // TODO: handle other
 }
+
+impl DKGError {
+	pub fn to_string(&self) -> String {
+		match self {
+			DKGError::KeygenMisbehaviour { bad_actors } => format!(
+				"Keygen misbehaviour: bad actors: {:?}",
+				bad_actors
+			),
+			DKGError::KeygenTimeout { bad_actors } => format!(
+				"Keygen timeout: bad actors: {:?}",
+				bad_actors
+			),
+			DKGError::OfflineMisbehaviour { bad_actors } => format!(
+				"Offline misbehaviour: bad actors: {:?}",
+				bad_actors
+			),
+			DKGError::OfflineTimeout { bad_actors } => format!(
+				"Offline timeout: bad actors: {:?}",
+				bad_actors
+			),
+			DKGError::SignMisbehaviour { bad_actors } => format!(
+				"Sign misbehaviour: bad actors: {:?}",
+				bad_actors
+			),
+			DKGError::SignTimeout { bad_actors } => format!(
+				"Sign timeout: bad actors: {:?}",
+				bad_actors
+			),
+			DKGError::StartKeygen { reason } => format!("Start keygen: {}", reason),
+			DKGError::CreateOfflineStage { reason } => format!("Create offline stage: {}", reason),
+			DKGError::CriticalError { reason } => format!("Critical error: {}", reason),
+			DKGError::GenericError { reason } => format!("Generic error: {}", reason),
+		}
+	}
+}

--- a/dkg-runtime-primitives/src/proposal.rs
+++ b/dkg-runtime-primitives/src/proposal.rs
@@ -187,7 +187,10 @@ impl ProposalType {
 }
 
 pub trait ProposalHandlerTrait {
-	fn handle_refresh_proposal(
+	fn handle_unsigned_refresh_proposal(
+		proposal: RefreshProposal
+	) -> frame_support::pallet_prelude::DispatchResult;
+	fn handle_signed_refresh_proposal(
 		proposal: RefreshProposal
 	) -> frame_support::pallet_prelude::DispatchResult;
 
@@ -227,7 +230,10 @@ pub trait ProposalHandlerTrait {
 }
 
 impl ProposalHandlerTrait for () {
-	fn handle_refresh_proposal(
+	fn handle_unsigned_refresh_proposal(
+		_proposal: RefreshProposal
+	) -> frame_support::pallet_prelude::DispatchResult { Ok(().into()) }
+	fn handle_signed_refresh_proposal(
 		_proposal: RefreshProposal
 	) -> frame_support::pallet_prelude::DispatchResult { Ok(().into()) }
 

--- a/dkg-runtime-primitives/src/proposal.rs
+++ b/dkg-runtime-primitives/src/proposal.rs
@@ -130,6 +130,8 @@ pub enum ProposalAction {
 
 #[derive(Debug, Encode, Decode, Clone, Eq, PartialEq, scale_info::TypeInfo)]
 pub enum ProposalType {
+	RefreshProposal { data: Vec<u8> },
+	RefreshProposalSigned { data: Vec<u8>, signature: Vec<u8> },
 	EVMUnsigned { data: Vec<u8> },
 	EVMSigned { data: Vec<u8>, signature: Vec<u8> },
 	AnchorUpdate { data: Vec<u8> },
@@ -147,6 +149,8 @@ pub enum ProposalType {
 impl ProposalType {
 	pub fn data(&self) -> Vec<u8> {
 		match self {
+			ProposalType::RefreshProposal { data } => data.clone(),
+			ProposalType::RefreshProposalSigned { data, .. } => data.clone(),
 			ProposalType::EVMUnsigned { data } => data.clone(),
 			ProposalType::EVMSigned { data, .. } => data.clone(),
 			ProposalType::AnchorUpdate { data } => data.clone(),
@@ -164,6 +168,8 @@ impl ProposalType {
 
 	pub fn signature(&self) -> Vec<u8> {
 		match self {
+			ProposalType::RefreshProposal { .. } => Vec::new(),
+			ProposalType::RefreshProposalSigned { signature, .. } => signature.clone(),
 			ProposalType::EVMUnsigned { .. } => Vec::new(),
 			ProposalType::EVMSigned { signature, .. } => signature.clone(),
 			ProposalType::AnchorUpdate { .. } => Vec::new(),
@@ -181,6 +187,10 @@ impl ProposalType {
 }
 
 pub trait ProposalHandlerTrait {
+	fn handle_refresh_proposal(
+		proposal: RefreshProposal
+	) -> frame_support::pallet_prelude::DispatchResult;
+
 	fn handle_unsigned_proposal(
 		proposal: Vec<u8>,
 		action: ProposalAction,
@@ -214,6 +224,46 @@ pub trait ProposalHandlerTrait {
 	fn handle_resource_id_update_signed_proposal(
 		prop: ProposalType,
 	) -> frame_support::pallet_prelude::DispatchResult;
+}
+
+impl ProposalHandlerTrait for () {
+	fn handle_refresh_proposal(
+		_proposal: RefreshProposal
+	) -> frame_support::pallet_prelude::DispatchResult { Ok(().into()) }
+
+	fn handle_unsigned_proposal(
+		_proposal: Vec<u8>,
+		_action: ProposalAction,
+	) -> frame_support::pallet_prelude::DispatchResult { Ok(().into()) }
+
+	fn handle_signed_proposal(
+		_prop: ProposalType,
+		_payload_key: DKGPayloadKey,
+	) -> frame_support::pallet_prelude::DispatchResult { Ok(().into()) }
+
+	fn handle_evm_signed_proposal(
+		_prop: ProposalType,
+	) -> frame_support::pallet_prelude::DispatchResult { Ok(().into()) }
+
+	fn handle_anchor_update_signed_proposal(
+		_prop: ProposalType,
+	) -> frame_support::pallet_prelude::DispatchResult { Ok(().into()) }
+
+	fn handle_token_add_signed_proposal(
+		_prop: ProposalType,
+	) -> frame_support::pallet_prelude::DispatchResult { Ok(().into()) }
+
+	fn handle_token_remove_signed_proposal(
+		_prop: ProposalType,
+	) -> frame_support::pallet_prelude::DispatchResult { Ok(().into()) }
+
+	fn handle_wrapping_fee_update_signed_proposal(
+		_prop: ProposalType,
+	) -> frame_support::pallet_prelude::DispatchResult { Ok(().into()) }
+
+	fn handle_resource_id_update_signed_proposal(
+		_prop: ProposalType,
+	) -> frame_support::pallet_prelude::DispatchResult { Ok(().into()) }
 }
 
 #[cfg(test)]

--- a/pallets/dkg-metadata/src/mock.rs
+++ b/pallets/dkg-metadata/src/mock.rs
@@ -133,6 +133,7 @@ impl pallet_dkg_metadata::Config for Test {
 	type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
 	type RefreshDelay = RefreshDelay;
 	type TimeToRestart = TimeToRestart;
+	type ProposalHandler = ();
 }
 
 parameter_types! {

--- a/pallets/dkg-metadata/src/tests.rs
+++ b/pallets/dkg-metadata/src/tests.rs
@@ -61,18 +61,11 @@ fn session_change_updates_authorities() {
 	new_test_ext(vec![1, 2, 3, 4]).execute_with(|| {
 		init_block(1);
 
-		assert!(0 == DKGMetadata::authority_set_id());
-
-		// no change - no log
-		assert!(System::digest().logs.is_empty());
-
-		init_block(2);
-
 		assert!(1 == DKGMetadata::authority_set_id());
 
 		let want = dkg_log(ConsensusLog::AuthoritiesChange {
 			next_authorities: AuthoritySet {
-				authorities: vec![mock_dkg_id(3), mock_dkg_id(4)],
+				authorities: vec![mock_dkg_id(1), mock_dkg_id(2)],
 				id: 1,
 			},
 			next_queued_authorities: AuthoritySet {
@@ -132,7 +125,7 @@ fn authority_set_updates_work() {
 
 		let vs = DKGMetadata::authority_set();
 
-		assert_eq!(vs.id, 0u64);
+		assert_eq!(vs.id, 1u64);
 		assert_eq!(want[0], vs.authorities[0]);
 		assert_eq!(want[1], vs.authorities[1]);
 
@@ -140,7 +133,7 @@ fn authority_set_updates_work() {
 
 		let vs = DKGMetadata::authority_set();
 
-		assert_eq!(vs.id, 1u64);
+		assert_eq!(vs.id, 2u64);
 		assert_eq!(want[2], vs.authorities[0]);
 		assert_eq!(want[3], vs.authorities[1]);
 	});

--- a/pallets/dkg-mmr/src/mock.rs
+++ b/pallets/dkg-mmr/src/mock.rs
@@ -166,6 +166,7 @@ impl pallet_dkg_metadata::Config for Test {
 	type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
 	type RefreshDelay = RefreshDelay;
 	type TimeToRestart = TimeToRestart;
+	type ProposalHandler = ();
 }
 
 parameter_types! {

--- a/pallets/dkg-mmr/src/tests.rs
+++ b/pallets/dkg-mmr/src/tests.rs
@@ -62,46 +62,6 @@ fn read_mmr_leaf(ext: &mut TestExternalities, index: usize) -> MmrLeaf {
 }
 
 #[test]
-fn should_contain_mmr_digest() {
-	let mut ext = new_test_ext(vec![1, 2, 3, 4]);
-	ext.execute_with(|| {
-		init_block(1);
-
-		assert_eq!(
-			System::digest().logs,
-			vec![dkg_log(ConsensusLog::MmrRoot(
-				hex!("15c0fac787cf2b6f1926d47bc414a345a9eacac13f2031b7efa0ad5fbd32d2f6").into()
-			))]
-		);
-
-		// unique every time
-		init_block(2);
-
-		assert_eq!(
-			System::digest().logs,
-			vec![
-				dkg_log(ConsensusLog::MmrRoot(
-					hex!("15c0fac787cf2b6f1926d47bc414a345a9eacac13f2031b7efa0ad5fbd32d2f6").into()
-				)),
-				dkg_log(ConsensusLog::AuthoritiesChange {
-					next_authorities: AuthoritySet {
-						authorities: vec![mock_dkg_id(3), mock_dkg_id(4),],
-						id: 1,
-					},
-					next_queued_authorities: AuthoritySet {
-						authorities: vec![mock_dkg_id(3), mock_dkg_id(4),],
-						id: 2,
-					}
-				}),
-				dkg_log(ConsensusLog::MmrRoot(
-					hex!("6613989435794047b2cdfba60ec2cdb265cb6e10cd8af406117872f7b8cdeb36").into()
-				)),
-			]
-		);
-	});
-}
-
-#[test]
 fn should_contain_valid_leaf_data() {
 	let mut ext = new_test_ext(vec![1, 2, 3, 4]);
 	ext.execute_with(|| {
@@ -115,7 +75,7 @@ fn should_contain_valid_leaf_data() {
 			version: MmrLeafVersion::new(1, 5),
 			parent_number_and_hash: (0_u64, H256::repeat_byte(0x45)),
 			dkg_next_authority_set: DKGNextAuthoritySet {
-				id: 1,
+				id: 2,
 				len: 2,
 				root: hex!("9c6b2c1b0d0b25a008e6c882cc7b415f309965c72ad2b944ac0931048ca31cd5")
 					.into(),
@@ -139,7 +99,7 @@ fn should_contain_valid_leaf_data() {
 			version: MmrLeafVersion::new(1, 5),
 			parent_number_and_hash: (1_u64, H256::repeat_byte(0x45)),
 			dkg_next_authority_set: DKGNextAuthoritySet {
-				id: 2,
+				id: 3,
 				len: 2,
 				root: hex!("9c6b2c1b0d0b25a008e6c882cc7b415f309965c72ad2b944ac0931048ca31cd5")
 					.into(),

--- a/pallets/dkg-proposal-handler/src/lib.rs
+++ b/pallets/dkg-proposal-handler/src/lib.rs
@@ -23,7 +23,7 @@ use frame_system::{
 };
 use sp_runtime::offchain::storage::StorageValueRef;
 use sp_std::{convert::TryFrom, vec::Vec};
-
+use sp_runtime::traits::Zero;
 pub mod weights;
 use weights::WeightInfo;
 
@@ -261,6 +261,17 @@ pub mod pallet {
 }
 
 impl<T: Config> ProposalHandlerTrait for Pallet<T> {
+	fn handle_refresh_proposal(proposal: dkg_runtime_primitives::RefreshProposal) -> DispatchResult {
+		let unsigned_proposal = ProposalType::RefreshProposal { data: proposal.encode() };
+		UnsignedProposalQueue::<T>::insert(
+			T::ChainId::zero(),
+			DKGPayloadKey::RefreshVote(proposal.nonce),
+			unsigned_proposal,
+		);
+
+		Ok(().into())
+	}
+
 	fn handle_unsigned_proposal(proposal: Vec<u8>, _action: ProposalAction) -> DispatchResult {
 		if let Ok(eth_transaction) = TransactionV2::decode(&mut &proposal[..]) {
 			ensure!(

--- a/pallets/dkg-proposal-handler/src/lib.rs
+++ b/pallets/dkg-proposal-handler/src/lib.rs
@@ -261,12 +261,21 @@ pub mod pallet {
 }
 
 impl<T: Config> ProposalHandlerTrait for Pallet<T> {
-	fn handle_refresh_proposal(proposal: dkg_runtime_primitives::RefreshProposal) -> DispatchResult {
+	fn handle_unsigned_refresh_proposal(proposal: dkg_runtime_primitives::RefreshProposal) -> DispatchResult {
 		let unsigned_proposal = ProposalType::RefreshProposal { data: proposal.encode() };
 		UnsignedProposalQueue::<T>::insert(
 			T::ChainId::zero(),
 			DKGPayloadKey::RefreshVote(proposal.nonce),
 			unsigned_proposal,
+		);
+
+		Ok(().into())
+	}
+
+	fn handle_signed_refresh_proposal(proposal: dkg_runtime_primitives::RefreshProposal) -> DispatchResult {
+		UnsignedProposalQueue::<T>::remove(
+			T::ChainId::zero(),
+			DKGPayloadKey::RefreshVote(proposal.nonce),
 		);
 
 		Ok(().into())

--- a/pallets/dkg-proposal-handler/src/mock.rs
+++ b/pallets/dkg-proposal-handler/src/mock.rs
@@ -14,15 +14,10 @@ use sp_runtime::{
 };
 
 use sp_core::offchain::{testing, OffchainDbExt, OffchainWorkerExt, TransactionPoolExt};
-
 use sp_keystore::{testing::KeyStore, KeystoreExt, SyncCryptoStore};
-
 use sp_runtime::RuntimeAppPublic;
-
 use dkg_runtime_primitives::{keccak_256, TransactionV2};
-
 use frame_support::traits::{OnFinalize, OnInitialize};
-
 use dkg_runtime_primitives::{
 	crypto::AuthorityId as DKGId, EIP2930Transaction, ProposalType, TransactionAction, U256,
 };
@@ -193,6 +188,7 @@ impl pallet_dkg_metadata::Config for Test {
 	type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
 	type RefreshDelay = RefreshDelay;
 	type TimeToRestart = TimeToRestart;
+	type ProposalHandler = DKGProposalHandler;
 }
 
 const PHRASE: &str = "news slush supreme milk chapter athlete soap sausage put clutch what kitten";

--- a/pallets/dkg-proposals/src/mock.rs
+++ b/pallets/dkg-proposals/src/mock.rs
@@ -148,6 +148,7 @@ impl pallet_dkg_metadata::Config for Test {
 	type NextSessionRotation = ParachainStaking;
 	type RefreshDelay = RefreshDelay;
 	type TimeToRestart = TimeToRestart;
+	type ProposalHandler = DKGProposalHandler;
 }
 
 parameter_types! {

--- a/pallets/dkg-proposals/src/mock.rs
+++ b/pallets/dkg-proposals/src/mock.rs
@@ -152,7 +152,7 @@ impl pallet_dkg_metadata::Config for Test {
 
 parameter_types! {
 	pub const MinimumPeriod: u64 = 1;
-	pub const RefreshDelay: Permill = Permill::from_percent(90);
+	pub const RefreshDelay: Permill = Permill::from_percent(50);
 	pub const TimeToRestart: u64 = 3;
 }
 

--- a/pallets/dkg-proposals/src/tests.rs
+++ b/pallets/dkg-proposals/src/tests.rs
@@ -552,23 +552,6 @@ fn should_get_initial_proposers_from_dkg() {
 	})
 }
 
-// In the DKG, when the session changes but the validators remain the same, it does not change the authority set, so the proposers should also not be reset.
-// This test checks that behaviour
-#[test]
-fn should_not_reset_proposers_if_authorities_have_not_changed() {
-	ExtBuilder::with_genesis_collators().execute_with(|| {
-		roll_to(15);
-		assert_does_not_have_event(Event::DKGProposals(crate::Event::ProposersReset {
-			proposers: vec![
-				mock_pub_key(0),
-				mock_pub_key(USER_A),
-				mock_pub_key(PROPOSER_A),
-				mock_pub_key(PROPOSER_B),
-			],
-		}))
-	})
-}
-
 // Should update proposers if new collator set has changed during a session change
 #[test]
 fn should_reset_proposers_if_authorities_changed_during_a_session_change() {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -676,9 +676,6 @@ construct_runtime!(
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>} = 20,
 		TransactionPayment: pallet_transaction_payment::{Pallet, Storage} = 21,
 
-
-
-
 		// Collator support. the order of these 4 are important and shall not change.
 		Authorship: pallet_authorship::{Pallet, Call, Storage} = 31,
 		ParachainStaking: parachain_staking::{Pallet, Call, Storage, Event<T>, Config<T>} = 32,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -553,6 +553,7 @@ impl pallet_dkg_metadata::Config for Runtime {
 	type NextSessionRotation = ParachainStaking;
 	type RefreshDelay = RefreshDelay;
 	type TimeToRestart = TimeToRestart;
+	type ProposalHandler = DKGProposalHandler;
 }
 
 parameter_types! {

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -510,13 +510,14 @@ impl pallet_dkg_metadata::Config for Runtime {
 	type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
 	type RefreshDelay = RefreshDelay;
 	type TimeToRestart = TimeToRestart;
+	type ProposalHandler = DKGProposalHandler;
 }
 
 parameter_types! {
 	pub const ChainIdentifier: u32 = 5;
 	pub const ProposalLifetime: BlockNumber = HOURS / 5;
 	pub const DKGAccountId: PalletId = PalletId(*b"dw/dkgac");
-	pub const RefreshDelay: Permill = Permill::from_percent(90);
+	pub const RefreshDelay: Permill = Permill::from_percent(50);
 	pub const TimeToRestart: BlockNumber = 3;
 }
 


### PR DESCRIPTION
# Overview
This PR fixes refresh submission and pushes more of the logic on-chain. We also rotate keys every session change now. This is useful for testing to see the DKG rotate frequently. We should aim to have this update differently for standalone nodes and parachains, namely:
- Parachains DKG authorities update each session and have longer sessions than standalone
- Standalone DKG authorities update each era and have shortter sessions

For now this will allow us to see behavior faster on live deployments.

## Refreshing
The refreshing mechanism might still be a bit wonky. There seems to be a proposal getting stuck in the queue although refresh continues to work and the nodes sign an update and it also displays what seems to be wrong data. I will continue to investigate this. Nonetheless, the refresh tx goes through using the same off-chain as other proposals and refresh is triggered on-chain rather than off-chain.