### PR TITLE
Refactors public key broadcast handler function

### DIFF
--- a/dkg-primitives/src/types.rs
+++ b/dkg-primitives/src/types.rs
@@ -163,6 +163,9 @@ pub enum DKGError {
 	CriticalError { reason: String },
 	GenericError { reason: String }, // TODO: handle other
 	SMNotFinished,
+	NotListeningForPublicKey,
+	NoAuthorityAccounts,
+	NoHeader
 }
 
 impl DKGError {
@@ -198,6 +201,7 @@ impl DKGError {
 			DKGError::CriticalError { reason } => format!("Critical error: {}", reason),
 			DKGError::GenericError { reason } => format!("Generic error: {}", reason),
 			DKGError::SMNotFinished => format!("SM not finished"),
+			_ => format!("Unknown error"),
 		}
 	}
 } 

--- a/pallets/dkg-metadata/src/lib.rs
+++ b/pallets/dkg-metadata/src/lib.rs
@@ -169,11 +169,8 @@ use frame_support::{ensure, pallet_prelude::*, transactional};
 			let origin = ensure_signed(origin)?;
 
 			let authorities = Self::current_authorities_accounts();
-
 			ensure!(authorities.contains(&origin), Error::<T>::MustBeAnActiveAuthority);
-
 			let dict = Self::process_public_key_submissions(keys_and_signatures, authorities);
-
 			let threshold = Self::signature_threshold();
 
 			let mut accepted = false;


### PR DESCRIPTION
This refactors the public key broadcast message handler into a few functions with the main goal of changing style and adding more `Result<(), DKGError>` return types.

Should be merged into (or after): https://github.com/webb-tools/dkg-substrate/pull/85