### PR TITLE
chore - add issue template and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,53 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: '[BUG] '
+labels: 'type: bug'
+assignees: ''
+
+---
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Run '....'
+3. See error
+
+
+
+**Log output**
+<!-- Please paste the log output derived from the error. -->
+<details>
+  <summary>Log Output</summary>
+  
+  ```Paste log output here
+  paste log output...
+  ```
+</details> 
+
+
+
+**Expected behaviour**
+<!-- A clear and concise description of what you expected to happen. -->
+
+
+
+**Screenshots**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+
+
+**Environment (please complete the following information):**
+ - OS: 
+ - Rust version(e.g. `rustc --version`)
+ - Branch/commit
+
+
+
+**Other information and links**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/checklist_issue.md
+++ b/.github/ISSUE_TEMPLATE/checklist_issue.md
@@ -1,0 +1,30 @@
+---
+name: Checklist issue type
+about: Creates a checklist of tasks that make up a larger milestone
+title: '[CHECKLIST] '
+labels: 'type: checklist'
+assignees: ''
+
+---
+
+# Overview
+<!-- A clear and concise description of what the intended outcome is for this checklist -->
+The goal of this checklist is to...
+
+## Checklist
+<!-- Outline the different issues that collectively make up this checklist -->
+
+### Functionality
+- [ ] # Issue number  
+- [ ] # Issue number  
+- [ ] # Issue number  
+
+### Testing
+- [ ] # Issue number  
+- [ ] # Issue number  
+- [ ] # Issue number 
+
+### Related Repos
+- [ ] # Issue number  
+- [ ] # Issue number  
+- [ ] # Issue number 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+    - name: Webb Telegram 
+      url: https://t.me/webbprotocol
+      about: Please ask questions here.
+    - name: Webb Discord Server
+      url: https://discord.com/invite/cv8EfJu3Tn
+      about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/new_issue.md
+++ b/.github/ISSUE_TEMPLATE/new_issue.md
@@ -1,0 +1,15 @@
+---
+name: New issue
+about: New issue template
+title: ''
+labels: 'needs triage'
+assignees: ''
+
+---
+
+**Issue summary**
+<!-- A clear and concise description of what the issue is. -->
+
+
+**Other information and links**
+<!-- Add any other context, existing implementation reference related to the task -->

--- a/.github/ISSUE_TEMPLATE/spec_issue.md
+++ b/.github/ISSUE_TEMPLATE/spec_issue.md
@@ -1,0 +1,26 @@
+---
+name: Spec issue
+about: Create a spec for dicussion and solution discovery
+title: '[SPEC] '
+labels: 'type: spec'
+assignees: ''
+
+---
+
+# Overview 
+<!-- A clear and concise description of what the intention of the spec is. -->
+
+## Research
+<!-- Provide any research conducted or link to -->
+
+## Examples 
+<!-- Provide any examples if possible -->
+
+# Questions/Issues
+<!-- Outline and questions, considerations or assumptions -->
+
+
+
+
+
+

--- a/.github/ISSUE_TEMPLATE/task_issue.md
+++ b/.github/ISSUE_TEMPLATE/task_issue.md
@@ -1,0 +1,22 @@
+---
+name: Task requirement
+about: Required tasks to complete 
+title: '[TASK] '
+labels: 'type: task'
+assignees: ''
+
+---
+
+**Task summary**
+<!-- A clear and concise description of what the task is. -->
+
+
+
+**Specification reference**
+<!-- Provide a reference to the specification or checklist task -->
+- 
+
+
+
+**Other information and links**
+<!-- Add any other related information or links -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+**Summary of changes**
+Changes introduced in this pull request:
+- 
+
+
+
+**Reference issue to close (if applicable)**
+<!-- Include the issue reference this pull request is connected to -->
+<!--(e.g. Closes #1)-->
+Closes 


### PR DESCRIPTION
Changes introduced in this pr:

Add issue templates for the following issue types:

- Bug report
- Checklist issue
- Spec issue
- Task issue 
- New issue

Along with a pull request template. 