### PR TITLE
chore: adds rust docs publication on push to master

### DIFF
--- a/.github/workflows/publish-rust-docs.yml
+++ b/.github/workflows/publish-rust-docs.yml
@@ -1,0 +1,37 @@
+name: Publish Docs
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  publish_docs:
+    if: github.event_name == 'push' && github.event.ref == 'refs/heads/master'
+    name: Publish Documentation
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+
+      - name: Update apt repositories
+        run: sudo apt update
+
+      - name: Build documentation
+        run: cargo doc --no-deps 
+      - name: Publish documentation
+        run: |
+          cd target/doc
+          git init
+          echo '<meta http-equiv="refresh" content="0; url=https://webb-tools.github.io/dkg-substrate/dkg_gadget/index.html">' > index.html
+          git add .
+          git -c user.name='ci' -c user.email='ci' commit -m 'Deploy documentation'
+          git push -f -q https://git:${{ secrets.github_token }}@github.com/${{ github.repository }} HEAD:gh-pages

--- a/scripts/build-rust-docs.sh
+++ b/scripts/build-rust-docs.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+cd target/doc
+git init
+echo '<meta http-equiv="refresh" content="0; url=https://webb-tools.github.io/dkg-substrate/dkg_gadget/index.html">' > index.html
+git add .
+git config --global -l
+git -c user.name='ci' -c user.email='ci' commit -m 'Deploy documentation'
+git push -f -q https://git:${GITHUB_TOKEN}@github.com/webb-tools/dkg-substrate HEAD:gh-pages


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- adds rust docs publication on push to master
- Once merged into `master` will be available at `https://webb-tools.github.io/dkg-substrate/`



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 
