### PR TITLE
chore: adds rococo-native feature

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -21,6 +21,9 @@ name = "dkg-node"
 [features]
 default = []
 runtime-benchmarks = ["dkg-runtime/runtime-benchmarks"]
+rococo-native = [
+	"polkadot-cli/rococo-native"
+]
 
 [dependencies]
 derive_more = "0.99.2"


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- adds rococo-native feature

This should remove the error:

```
 Error: Input("Relay chain argument error: Invalid input: `rococo-local` only supported with `rococo-native` feature enabled.")
```

To build:

```
cargo build --release -p dkg-node --features rococo-native
```


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 
