### PR TITLE
Multiple sign protocol execution

### DIFF
--- a/dkg-gadget/src/meta_async_rounds/meta_handler.rs
+++ b/dkg-gadget/src/meta_async_rounds/meta_handler.rs
@@ -219,7 +219,6 @@ where
 							}
 						} else {
 							log::warn!(target: "dkg", "🕸️  We are not among signers, skipping");
-							return Ok(())
 						}
 					}
 
@@ -228,9 +227,9 @@ where
 					// each batch of unsigned proposals concurrently
 					futures.try_collect::<()>().await.map(|_| ())?;
 					log::info!(
-							"Concluded all Offline->Voting stages ({} total) for this batch for this node",
-							count_in_batch
-						);
+						"Concluded all Offline->Voting stages ({} total) for this batch for this node",
+						count_in_batch
+					);
 				}
 			} else {
 				log::info!(target: "dkg", "Will skip keygen since local is NOT in best

--- a/dkg-gadget/src/meta_async_rounds/state_machine_interface.rs
+++ b/dkg-gadget/src/meta_async_rounds/state_machine_interface.rs
@@ -134,6 +134,7 @@ impl StateMachineIface for OfflineStage {
 		Receiver<Arc<SignedDKGMessage<Public>>>,
 		Threshold,
 		BatchKey,
+		[u8; 32],
 	);
 	type Return = ();
 
@@ -196,6 +197,7 @@ impl StateMachineIface for OfflineStage {
 			unsigned_proposal.2,
 			unsigned_proposal.3,
 			unsigned_proposal.4,
+			unsigned_proposal.5,
 		)?
 		.await?;
 		Ok(())

--- a/dkg-primitives/src/types.rs
+++ b/dkg-primitives/src/types.rs
@@ -59,6 +59,14 @@ impl<AuthorityId> SignedDKGMessage<AuthorityId> {
 	{
 		<<B::Header as Header>::Hashing as Hash>::hash_of(&self.msg)
 	}
+
+	pub fn identifier(&self) -> [u8; 32] {
+		match &self.msg.payload {
+			DKGMsgPayload::Offline(m) => [0u8; 32],
+			DKGMsgPayload::Vote(m) => [0u8; 32],
+			_ => [0u8; 32],
+		}
+	}
 }
 
 impl<ID> fmt::Display for DKGMessage<ID> {
@@ -125,6 +133,8 @@ pub struct DKGOfflineMessage {
 	pub signer_set_id: SignerSetId,
 	/// Serialized offline stage msg
 	pub offline_msg: Vec<u8>,
+	/// Auxiliary identifier for separating offline messages across concurrent sign rounds
+	pub identifier: [u8; 32],
 }
 
 #[derive(Debug, Clone, Decode, Encode)]
@@ -136,6 +146,8 @@ pub struct DKGVoteMessage {
 	pub round_key: Vec<u8>,
 	/// Serialized partial signature
 	pub partial_signature: Vec<u8>,
+	/// Auxiliary identifier for separating voting messages across concurrent sign rounds
+	pub identifier: [u8; 32],
 }
 
 #[derive(Debug, Clone, Decode, Encode)]


### PR DESCRIPTION
**Summary of changes**
Attempts to run the signing protocol for other subsets of signers to cover the cases that other signers misbehave and stop participating. The rudimentary idea is to randomly select other sets of $t+1$ signers and to simultaneously execute $((t+1 / 2) + 1$ signing protocols in parallel.

Nonetheless, currently it seems like they don't execute in parallel and only one continues to execute. CC @tbraun96 if you have ideas here.

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 
