### PR TITLE
Reorder runtime to allow for DKG to setup before Session

### DIFF
--- a/pallets/dkg-metadata/src/lib.rs
+++ b/pallets/dkg-metadata/src/lib.rs
@@ -475,7 +475,8 @@ pub mod pallet {
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config> {
 		pub authorities: Vec<T::DKGId>,
-		pub threshold: u32,
+		pub keygen_threshold: u16,
+		pub signature_threshold: u16,
 		pub authority_ids: Vec<T::AccountId>,
 	}
 
@@ -539,30 +540,39 @@ pub mod pallet {
 	#[cfg(feature = "std")]
 	impl<T: Config> Default for GenesisConfig<T> {
 		fn default() -> Self {
-			Self { authorities: Vec::new(), threshold: 0, authority_ids: Vec::new() }
+			Self {
+				authorities: Vec::new(),
+				signature_threshold: 1,
+				keygen_threshold: 3,
+				authority_ids: Vec::new()
+			}
 		}
 	}
 
 	#[pallet::genesis_build]
 	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
 		fn build(&self) {
-			let mut signature_threshold = 1u16;
-			let keygen_threshold = u16::try_from(self.authorities.len()).unwrap();
-
-			if keygen_threshold <= signature_threshold {
-				signature_threshold = keygen_threshold - 1;
-			}
-
+			assert!(self.signature_threshold < self.keygen_threshold, "Signature threshold must be less than keygen threshold");
+			assert!(self.keygen_threshold > 1, "Keygen threshold must be greater than 1");
+			assert!(self.authority_ids.len() >= self.keygen_threshold as usize, "Not enough authority ids specified");
 			// Set thresholds to be the same
-			SignatureThreshold::<T>::put(signature_threshold);
-			KeygenThreshold::<T>::put(keygen_threshold);
-			NextSignatureThreshold::<T>::put(signature_threshold);
-			NextKeygenThreshold::<T>::put(keygen_threshold);
-			PendingSignatureThreshold::<T>::put(signature_threshold);
-			PendingKeygenThreshold::<T>::put(keygen_threshold);
+			SignatureThreshold::<T>::put(self.signature_threshold);
+			KeygenThreshold::<T>::put(self.keygen_threshold);
+			NextSignatureThreshold::<T>::put(self.signature_threshold);
+			NextKeygenThreshold::<T>::put(self.keygen_threshold);
+			PendingSignatureThreshold::<T>::put(self.signature_threshold);
+			PendingKeygenThreshold::<T>::put(self.keygen_threshold);
 			// Set refresh parameters
 			RefreshDelay::<T>::put(T::RefreshDelay::get());
 			RefreshNonce::<T>::put(0);
+			#[cfg(feature = "std")] {
+				println!("Keygen threshold: {}", KeygenThreshold::<T>::get());
+				println!("Signature threshold: {}", SignatureThreshold::<T>::get());
+				println!("Next keygen threshold: {}", NextKeygenThreshold::<T>::get());
+				println!("Next signature threshold: {}", NextSignatureThreshold::<T>::get());
+				println!("Pending keygen threshold: {}", PendingKeygenThreshold::<T>::get());
+				println!("Pending signature threshold: {}", PendingSignatureThreshold::<T>::get());
+			}
 		}
 	}
 
@@ -1339,6 +1349,14 @@ impl<T: Config> Pallet<T> {
 		if authorities.is_empty() {
 			return
 		}
+		#[cfg(feature = "std")] {
+			println!("Keygen threshold: {}", KeygenThreshold::<T>::get());
+			println!("Signature threshold: {}", SignatureThreshold::<T>::get());
+			println!("Next keygen threshold: {}", NextKeygenThreshold::<T>::get());
+			println!("Next signature threshold: {}", NextSignatureThreshold::<T>::get());
+			println!("Pending keygen threshold: {}", PendingKeygenThreshold::<T>::get());
+			println!("Pending signature threshold: {}", PendingSignatureThreshold::<T>::get());
+		}
 		assert!(Authorities::<T>::get().is_empty(), "Authorities are already initialized!");
 		// Initialize current authorities
 		Authorities::<T>::put(authorities);
@@ -1348,9 +1366,15 @@ impl<T: Config> Pallet<T> {
 		NextAuthorities::<T>::put(authorities);
 		NextAuthoritySetId::<T>::put(1);
 		NextAuthoritiesAccounts::<T>::put(authority_account_ids);
-		let best_authorities = Self::get_best_authorities(authorities.len(), authorities);
+		let best_authorities = Self::get_best_authorities(
+			Self::keygen_threshold() as usize,
+			authorities
+		);
 		BestAuthorities::<T>::put(best_authorities);
-		let next_best_authorities = Self::get_best_authorities(authorities.len(), authorities);
+		let next_best_authorities = Self::get_best_authorities(
+			Self::keygen_threshold() as usize,
+			authorities
+		);
 		NextBestAuthorities::<T>::put(next_best_authorities);
 
 		<T::OnAuthoritySetChangeHandler as OnAuthoritySetChangeHandler<

--- a/pallets/dkg-metadata/src/lib.rs
+++ b/pallets/dkg-metadata/src/lib.rs
@@ -565,14 +565,6 @@ pub mod pallet {
 			// Set refresh parameters
 			RefreshDelay::<T>::put(T::RefreshDelay::get());
 			RefreshNonce::<T>::put(0);
-			#[cfg(feature = "std")] {
-				println!("Keygen threshold: {}", KeygenThreshold::<T>::get());
-				println!("Signature threshold: {}", SignatureThreshold::<T>::get());
-				println!("Next keygen threshold: {}", NextKeygenThreshold::<T>::get());
-				println!("Next signature threshold: {}", NextSignatureThreshold::<T>::get());
-				println!("Pending keygen threshold: {}", PendingKeygenThreshold::<T>::get());
-				println!("Pending signature threshold: {}", PendingSignatureThreshold::<T>::get());
-			}
 		}
 	}
 
@@ -1348,14 +1340,6 @@ impl<T: Config> Pallet<T> {
 	fn initialize_authorities(authorities: &[T::DKGId], authority_account_ids: &[T::AccountId]) {
 		if authorities.is_empty() {
 			return
-		}
-		#[cfg(feature = "std")] {
-			println!("Keygen threshold: {}", KeygenThreshold::<T>::get());
-			println!("Signature threshold: {}", SignatureThreshold::<T>::get());
-			println!("Next keygen threshold: {}", NextKeygenThreshold::<T>::get());
-			println!("Next signature threshold: {}", NextSignatureThreshold::<T>::get());
-			println!("Pending keygen threshold: {}", PendingKeygenThreshold::<T>::get());
-			println!("Pending signature threshold: {}", PendingSignatureThreshold::<T>::get());
 		}
 		assert!(Authorities::<T>::get().is_empty(), "Authorities are already initialized!");
 		// Initialize current authorities

--- a/pallets/dkg-metadata/src/lib.rs
+++ b/pallets/dkg-metadata/src/lib.rs
@@ -544,7 +544,7 @@ pub mod pallet {
 				authorities: Vec::new(),
 				signature_threshold: 1,
 				keygen_threshold: 3,
-				authority_ids: Vec::new()
+				authority_ids: Vec::new(),
 			}
 		}
 	}
@@ -552,9 +552,15 @@ pub mod pallet {
 	#[pallet::genesis_build]
 	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
 		fn build(&self) {
-			assert!(self.signature_threshold < self.keygen_threshold, "Signature threshold must be less than keygen threshold");
+			assert!(
+				self.signature_threshold < self.keygen_threshold,
+				"Signature threshold must be less than keygen threshold"
+			);
 			assert!(self.keygen_threshold > 1, "Keygen threshold must be greater than 1");
-			assert!(self.authority_ids.len() >= self.keygen_threshold as usize, "Not enough authority ids specified");
+			assert!(
+				self.authority_ids.len() >= self.keygen_threshold as usize,
+				"Not enough authority ids specified"
+			);
 			// Set thresholds to be the same
 			SignatureThreshold::<T>::put(self.signature_threshold);
 			KeygenThreshold::<T>::put(self.keygen_threshold);
@@ -1350,15 +1356,11 @@ impl<T: Config> Pallet<T> {
 		NextAuthorities::<T>::put(authorities);
 		NextAuthoritySetId::<T>::put(1);
 		NextAuthoritiesAccounts::<T>::put(authority_account_ids);
-		let best_authorities = Self::get_best_authorities(
-			Self::keygen_threshold() as usize,
-			authorities
-		);
+		let best_authorities =
+			Self::get_best_authorities(Self::keygen_threshold() as usize, authorities);
 		BestAuthorities::<T>::put(best_authorities);
-		let next_best_authorities = Self::get_best_authorities(
-			Self::keygen_threshold() as usize,
-			authorities
-		);
+		let next_best_authorities =
+			Self::get_best_authorities(Self::keygen_threshold() as usize, authorities);
 		NextBestAuthorities::<T>::put(next_best_authorities);
 
 		<T::OnAuthoritySetChangeHandler as OnAuthoritySetChangeHandler<

--- a/standalone/node/src/chain_spec.rs
+++ b/standalone/node/src/chain_spec.rs
@@ -356,7 +356,8 @@ fn testnet_genesis(
 		grandpa: Default::default(),
 		dkg: DKGConfig {
 			authorities: initial_authorities.iter().map(|(.., x)| x.clone()).collect::<_>(),
-			threshold: Default::default(),
+			keygen_threshold: 2,
+			signature_threshold: 1,
 			authority_ids: initial_authorities.iter().map(|(x, ..)| x.clone()).collect::<_>(),
 		},
 		dkg_proposals: DKGProposalsConfig { initial_chain_ids, initial_r_ids, initial_proposers },

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -698,6 +698,9 @@ construct_runtime!(
 	Aura: pallet_aura,
 	Grandpa: pallet_grandpa,
 	Balances: pallet_balances,
+	DKG: pallet_dkg_metadata,
+	DKGProposals: pallet_dkg_proposals,
+	DKGProposalHandler: pallet_dkg_proposal_handler
 	TransactionPayment: pallet_transaction_payment,
 	Sudo: pallet_sudo,
 	ElectionProviderMultiPhase: pallet_election_provider_multi_phase,
@@ -706,9 +709,6 @@ construct_runtime!(
 	Staking: pallet_staking,
 	Session: pallet_session,
 	Historical: pallet_session_historical,
-	DKG: pallet_dkg_metadata,
-	DKGProposals: pallet_dkg_proposals,
-	DKGProposalHandler: pallet_dkg_proposal_handler
   }
 );
 

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -700,7 +700,7 @@ construct_runtime!(
 	Balances: pallet_balances,
 	DKG: pallet_dkg_metadata,
 	DKGProposals: pallet_dkg_proposals,
-	DKGProposalHandler: pallet_dkg_proposal_handler
+	DKGProposalHandler: pallet_dkg_proposal_handler,
 	TransactionPayment: pallet_transaction_payment,
 	Sudo: pallet_sudo,
 	ElectionProviderMultiPhase: pallet_election_provider_multi_phase,


### PR DESCRIPTION
**Summary of changes**
- Runs DKG genesis configuration before Session pallet does to ensure that DKG is instantiated before genesis session handler.