### PR TITLE
Add signed handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4720,6 +4720,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
+ "webb-proposals",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9559,9 +9559,9 @@ dependencies = [
 
 [[package]]
 name = "webb-proposals"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c60247d1c5faa97122408138ebaaab6b69bbae8cc502f229fa122a194db83d29"
+checksum = "7b9869641d13a639c137fd1b54b9e3b6d80b5cb0b10caac6dc00d6a9c1228590"
 dependencies = [
  "num-traits",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1504,6 +1504,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "wasm-timer",
+ "webb-proposals",
 ]
 
 [[package]]
@@ -4690,6 +4691,7 @@ dependencies = [
  "sp-runtime",
  "sp-staking",
  "sp-std",
+ "webb-proposals",
 ]
 
 [[package]]
@@ -7154,6 +7156,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1847b767a3d62d95cbf3d8a9f0e421cf57a0d8aa4f411d4b16525afb0284d4ed"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4d7e1b012cb3d9129567661a63755ea4b8a7386d339dc945ae187e403c6743"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "schnorrkel"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7317,6 +7343,17 @@ name = "serde_derive"
 version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9521,13 +9558,16 @@ dependencies = [
 
 [[package]]
 name = "webb-proposals"
-version = "0.3.7"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf68d775c25b9b31e4b83e12971b7bcacaec28541a8944b7d7e4fc987f8691e2"
+checksum = "c60247d1c5faa97122408138ebaaab6b69bbae8cc502f229fa122a194db83d29"
 dependencies = [
  "num-traits",
  "parity-scale-codec",
  "scale-info",
+ "schemars",
+ "serde",
+ "tiny-keccak",
  "typed-builder 0.10.0",
 ]
 

--- a/dkg-gadget/Cargo.toml
+++ b/dkg-gadget/Cargo.toml
@@ -56,6 +56,8 @@ async-trait = "0.1.53"
 auto_impl = "1.0.0"
 itertools = "0.10.3"
 
+webb-proposals = { version = "0.4.3", default-features = false, features = ["scale", "evm", "substrate"] }
+
 # Local dependencies
 dkg-runtime-primitives = { path = "../dkg-runtime-primitives", default-features = false }
 dkg-primitives = { path = "../dkg-primitives", default-features = false }

--- a/dkg-gadget/Cargo.toml
+++ b/dkg-gadget/Cargo.toml
@@ -56,7 +56,7 @@ async-trait = "0.1.53"
 auto_impl = "1.0.0"
 itertools = "0.10.3"
 
-webb-proposals = { version = "0.4.3", default-features = false, features = ["scale", "evm", "substrate"] }
+webb-proposals = { version = "0.4.4", default-features = false, features = ["scale", "evm", "substrate"] }
 
 # Local dependencies
 dkg-runtime-primitives = { path = "../dkg-runtime-primitives", default-features = false }

--- a/dkg-gadget/src/async_protocols/blockchain_interface.rs
+++ b/dkg-gadget/src/async_protocols/blockchain_interface.rs
@@ -32,7 +32,7 @@ use dkg_primitives::{
 };
 use dkg_runtime_primitives::{
 	crypto::{AuthorityId, Public},
-	AggregatedPublicKeys, AuthoritySet, Proposal, UnsignedProposal,
+	AggregatedPublicKeys, AuthoritySet, UnsignedProposal,
 };
 use multi_party_ecdsa::protocols::multi_party_ecdsa::gg_2020::{
 	party_i::SignatureRecid, state_machine::keygen::LocalKey,
@@ -43,6 +43,7 @@ use sc_keystore::LocalKeystore;
 use sp_arithmetic::traits::AtLeast32BitUnsigned;
 use sp_runtime::traits::{Block, NumberFor};
 use std::{collections::HashMap, fmt::Debug, marker::PhantomData, path::PathBuf, sync::Arc};
+use webb_proposals::Proposal;
 
 #[auto_impl::auto_impl(Arc,&,&mut)]
 pub trait BlockchainInterface: Send + Sync {

--- a/dkg-gadget/src/async_protocols/test_utils.rs
+++ b/dkg-gadget/src/async_protocols/test_utils.rs
@@ -10,12 +10,13 @@ use dkg_primitives::{
 	},
 	utils::convert_signature,
 };
-use dkg_runtime_primitives::{crypto::Public, Proposal, ProposalKind, UnsignedProposal};
+use dkg_runtime_primitives::{crypto::Public, UnsignedProposal};
 use multi_party_ecdsa::protocols::multi_party_ecdsa::gg_2020::{
 	party_i::SignatureRecid, state_machine::keygen::LocalKey,
 };
 use parking_lot::Mutex;
 use std::{collections::HashMap, sync::Arc};
+use webb_proposals::{Proposal, ProposalKind};
 
 pub(crate) type VoteResults =
 	Arc<Mutex<HashMap<BatchKey, Vec<(Proposal, SignatureRecid, BigInt)>>>>;

--- a/dkg-gadget/src/proposal.rs
+++ b/dkg-gadget/src/proposal.rs
@@ -18,13 +18,14 @@ use codec::Encode;
 use dkg_primitives::types::DKGSignedPayload;
 use dkg_runtime_primitives::{
 	crypto::AuthorityId, offchain::storage_keys::OFFCHAIN_PUBLIC_KEY_SIG, DKGApi, DKGPayloadKey,
-	Proposal, ProposalKind, RefreshProposalSigned,
+	RefreshProposalSigned,
 };
 use log::{info, trace};
 use sc_client_api::Backend;
 use sp_api::offchain::STORAGE_PREFIX;
 use sp_core::offchain::OffchainStorage;
 use sp_runtime::traits::{Block, Header};
+use webb_proposals::{Proposal, ProposalKind};
 
 /// Get signed proposal
 pub(crate) fn get_signed_proposal<B, C, BE>(

--- a/dkg-gadget/src/storage/proposals.rs
+++ b/dkg-gadget/src/storage/proposals.rs
@@ -20,7 +20,7 @@ use codec::{Decode, Encode};
 use dkg_runtime_primitives::{
 	crypto::{AuthorityId, Public},
 	offchain::storage_keys::OFFCHAIN_SIGNED_PROPOSALS,
-	AuthoritySet, DKGApi, OffchainSignedProposals, Proposal,
+	AuthoritySet, DKGApi, OffchainSignedProposals,
 };
 use log::debug;
 use parking_lot::RwLock;
@@ -29,6 +29,7 @@ use sc_client_api::Backend;
 use sp_application_crypto::sp_core::offchain::{OffchainStorage, STORAGE_PREFIX};
 use sp_runtime::traits::{Block, Header, NumberFor};
 use std::sync::Arc;
+use webb_proposals::Proposal;
 
 /// processes signed proposals and puts them in storage
 pub(crate) fn save_signed_proposals_in_storage<B, C, BE>(

--- a/dkg-runtime-primitives/Cargo.toml
+++ b/dkg-runtime-primitives/Cargo.toml
@@ -18,7 +18,7 @@ ethereum = { version = "0.12.0", default-features = false, features = [
 	"with-codec",
 ] }
 ethereum-types = { version = "0.13.1", default-features = false }
-webb-proposals = { version = "0.4.3", default-features = false, features = ["scale", "evm", "substrate"] }
+webb-proposals = { version = "0.4.4", default-features = false, features = ["scale", "evm", "substrate"] }
 
 hex = { version = "0.4", default-features = false }
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.26", default-features = false }

--- a/dkg-runtime-primitives/Cargo.toml
+++ b/dkg-runtime-primitives/Cargo.toml
@@ -18,7 +18,7 @@ ethereum = { version = "0.12.0", default-features = false, features = [
 	"with-codec",
 ] }
 ethereum-types = { version = "0.13.1", default-features = false }
-webb-proposals = { version = "0.3.2", default-features = false, features = ["scale", "evm", "substrate"] }
+webb-proposals = { version = "0.4.3", default-features = false, features = ["scale", "evm", "substrate"] }
 
 hex = { version = "0.4", default-features = false }
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.26", default-features = false }
@@ -45,4 +45,5 @@ std = [
 	"sp-application-crypto/std",
 	"frame-system/std",
 	"frame-support/std",
+	"webb-proposals/std",
 ]

--- a/dkg-runtime-primitives/src/handlers/decode_proposals.rs
+++ b/dkg-runtime-primitives/src/handlers/decode_proposals.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+use super::substrate;
 use crate::{
 	handlers::{evm, validate_proposals::ValidationError},
-	DKGPayloadKey, Proposal, ProposalKind,
+	DKGPayloadKey,
 };
-
-use super::substrate;
+use webb_proposals::{Proposal, ProposalKind};
 
 pub fn decode_proposal_header(
 	data: &[u8],

--- a/dkg-runtime-primitives/src/lib.rs
+++ b/dkg-runtime-primitives/src/lib.rs
@@ -38,6 +38,7 @@ use sp_runtime::{
 };
 use sp_std::{prelude::*, vec::Vec};
 use tiny_keccak::{Hasher, Keccak};
+use webb_proposals::Proposal;
 
 /// Utility fn to calculate keccak 256 has
 pub fn keccak_256(data: &[u8]) -> [u8; 32] {

--- a/dkg-runtime-primitives/src/proposal.rs
+++ b/dkg-runtime-primitives/src/proposal.rs
@@ -21,8 +21,8 @@ use sp_std::vec::Vec;
 pub const PROPOSAL_SIGNATURE_LENGTH: usize = 65;
 
 pub use webb_proposals::{
-	FunctionSignature, Nonce as ProposalNonce, ProposalHeader, ResourceId, TypedChainId,
-	Proposal, ProposalKind,
+	FunctionSignature, Nonce as ProposalNonce, Proposal, ProposalHeader, ProposalKind, ResourceId,
+	TypedChainId,
 };
 
 #[derive(Clone, RuntimeDebug, scale_info::TypeInfo)]

--- a/dkg-runtime-primitives/src/proposal.rs
+++ b/dkg-runtime-primitives/src/proposal.rs
@@ -17,12 +17,12 @@ use sp_std::hash::{Hash, Hasher};
 
 use codec::{Decode, Encode};
 use sp_std::vec::Vec;
-use webb_proposals::Proposal;
 
 pub const PROPOSAL_SIGNATURE_LENGTH: usize = 65;
 
 pub use webb_proposals::{
 	FunctionSignature, Nonce as ProposalNonce, ProposalHeader, ResourceId, TypedChainId,
+	Proposal, ProposalKind,
 };
 
 #[derive(Clone, RuntimeDebug, scale_info::TypeInfo)]

--- a/dkg-runtime-primitives/src/proposal.rs
+++ b/dkg-runtime-primitives/src/proposal.rs
@@ -17,6 +17,7 @@ use sp_std::hash::{Hash, Hasher};
 
 use codec::{Decode, Encode};
 use sp_std::vec::Vec;
+use webb_proposals::Proposal;
 
 pub const PROPOSAL_SIGNATURE_LENGTH: usize = 65;
 
@@ -130,83 +131,6 @@ pub enum ProposalAction {
 	// sign the proposal with some priority
 	Sign(u8),
 }
-
-#[derive(Debug, Encode, Decode, Clone, Eq, PartialEq, scale_info::TypeInfo)]
-pub enum Proposal {
-	Signed { kind: ProposalKind, data: Vec<u8>, signature: Vec<u8> },
-	Unsigned { kind: ProposalKind, data: Vec<u8> },
-}
-
-#[derive(Debug, Encode, Decode, Clone, Eq, PartialEq, scale_info::TypeInfo)]
-pub enum ProposalKind {
-	Refresh,
-	ProposerSetUpdate,
-	EVM,
-	AnchorCreate,
-	AnchorUpdate,
-	TokenAdd,
-	TokenRemove,
-	WrappingFeeUpdate,
-	ResourceIdUpdate,
-	RescueTokens,
-	MaxDepositLimitUpdate,
-	MinWithdrawalLimitUpdate,
-	SetVerifier,
-	SetTreasuryHandler,
-	FeeRecipientUpdate,
-}
-
-impl Proposal {
-	pub fn data(&self) -> &Vec<u8> {
-		match self {
-			Proposal::Signed { data, .. } | Proposal::Unsigned { data, .. } => data,
-		}
-	}
-
-	pub fn signature(&self) -> Option<Vec<u8>> {
-		match self {
-			Proposal::Signed { signature, .. } => Some(signature.clone()),
-			Proposal::Unsigned { .. } => None,
-		}
-	}
-
-	pub fn kind(&self) -> ProposalKind {
-		match self {
-			Proposal::Signed { kind, .. } | Proposal::Unsigned { kind, .. } => kind.clone(),
-		}
-	}
-
-	pub fn is_signed(&self) -> bool {
-		matches!(self, Proposal::Signed { .. })
-	}
-
-	pub fn is_unsigned(&self) -> bool {
-		matches!(self, Proposal::Unsigned { .. })
-	}
-
-	pub fn get_payload_key(&self, nonce: ProposalNonce) -> DKGPayloadKey {
-		match self.kind() {
-			ProposalKind::EVM => DKGPayloadKey::EVMProposal(nonce),
-			ProposalKind::AnchorCreate => DKGPayloadKey::AnchorCreateProposal(nonce),
-			ProposalKind::AnchorUpdate => DKGPayloadKey::AnchorUpdateProposal(nonce),
-			ProposalKind::TokenAdd => DKGPayloadKey::TokenAddProposal(nonce),
-			ProposalKind::TokenRemove => DKGPayloadKey::TokenRemoveProposal(nonce),
-			ProposalKind::WrappingFeeUpdate => DKGPayloadKey::WrappingFeeUpdateProposal(nonce),
-			ProposalKind::ResourceIdUpdate => DKGPayloadKey::ResourceIdUpdateProposal(nonce),
-			ProposalKind::RescueTokens => DKGPayloadKey::RescueTokensProposal(nonce),
-			ProposalKind::MaxDepositLimitUpdate =>
-				DKGPayloadKey::MaxDepositLimitUpdateProposal(nonce),
-			ProposalKind::MinWithdrawalLimitUpdate =>
-				DKGPayloadKey::MinWithdrawalLimitUpdateProposal(nonce),
-			ProposalKind::SetVerifier => DKGPayloadKey::SetVerifierProposal(nonce),
-			ProposalKind::SetTreasuryHandler => DKGPayloadKey::SetTreasuryHandlerProposal(nonce),
-			ProposalKind::FeeRecipientUpdate => DKGPayloadKey::FeeRecipientUpdateProposal(nonce),
-			ProposalKind::Refresh => DKGPayloadKey::RefreshVote(nonce),
-			ProposalKind::ProposerSetUpdate => DKGPayloadKey::ProposerSetUpdateProposal(nonce),
-		}
-	}
-}
-
 pub trait ProposalHandlerTrait {
 	fn handle_unsigned_proposal(
 		_proposal: Vec<u8>,

--- a/dkg-test-suite/src/evm/testFeeRecipientUpdateProposal.ts
+++ b/dkg-test-suite/src/evm/testFeeRecipientUpdateProposal.ts
@@ -86,10 +86,10 @@ async function sendFeeRecipientUpdateProposal(api: ApiPromise) {
 		Evm: 5001,
 	});
 	const kind = api.createType(
-		'DkgRuntimePrimitivesProposalProposalKind',
+		'WebbProposalsProposalProposalKind',
 		'FeeRecipientUpdate'
 	);
-	const proposal = api.createType('DkgRuntimePrimitivesProposal', {
+	const proposal = api.createType('WebbProposalsProposal', {
 		Unsigned: {
 			kind: kind,
 			data: prop,

--- a/dkg-test-suite/src/evm/testResourceIdUpdateProposal.ts
+++ b/dkg-test-suite/src/evm/testResourceIdUpdateProposal.ts
@@ -85,10 +85,10 @@ async function sendResourceIdUpdateProposal(api: ApiPromise) {
 		Evm: 5001,
 	});
 	const kind = api.createType(
-		'DkgRuntimePrimitivesProposalProposalKind',
+		'WebbProposalsProposalProposalKind',
 		'ResourceIdUpdate'
 	);
-	const proposal = api.createType('DkgRuntimePrimitivesProposal', {
+	const proposal = api.createType('WebbProposalsProposal', {
 		Unsigned: {
 			kind: kind,
 			data: prop,

--- a/dkg-test-suite/src/evm/testSetTreasuryHandlerProposal.ts
+++ b/dkg-test-suite/src/evm/testSetTreasuryHandlerProposal.ts
@@ -86,10 +86,10 @@ async function sendSetTreasuryHandlerProposal(api: ApiPromise) {
 		Evm: 5001,
 	});
 	const kind = api.createType(
-		'DkgRuntimePrimitivesProposalProposalKind',
+		'WebbProposalsProposalProposalKind',
 		'SetTreasuryHandler'
 	);
-	const proposal = api.createType('DkgRuntimePrimitivesProposal', {
+	const proposal = api.createType('WebbProposalsProposal', {
 		Unsigned: {
 			kind: kind,
 			data: prop,

--- a/dkg-test-suite/src/evm/testSetVerifierProposal.ts
+++ b/dkg-test-suite/src/evm/testSetVerifierProposal.ts
@@ -82,10 +82,10 @@ async function sendSetVerifierProposal(api: ApiPromise) {
 		Evm: 5001,
 	});
 	const kind = api.createType(
-		'DkgRuntimePrimitivesProposalProposalKind',
+		'WebbProposalsProposalProposalKind',
 		'SetVerifier'
 	);
-	const proposal = api.createType('DkgRuntimePrimitivesProposal', {
+	const proposal = api.createType('WebbProposalsProposal', {
 		Unsigned: {
 			kind: kind,
 			data: prop,

--- a/dkg-test-suite/src/evm/testWrappingFeeUpdateProposal.ts
+++ b/dkg-test-suite/src/evm/testWrappingFeeUpdateProposal.ts
@@ -85,10 +85,10 @@ async function sendWrappingFeeUpdateProposal(api: ApiPromise) {
 		Evm: 5001,
 	});
 	const kind = api.createType(
-		'DkgRuntimePrimitivesProposalProposalKind',
+		'WebbProposalsProposalProposalKind',
 		'WrappingFeeUpdate'
 	);
-	const proposal = api.createType('DkgRuntimePrimitivesProposal', {
+	const proposal = api.createType('WebbProposalsProposal', {
 		Unsigned: {
 			kind: kind,
 			data: prop,

--- a/dkg-test-suite/src/evm/token/testTokenAddProposal.ts
+++ b/dkg-test-suite/src/evm/token/testTokenAddProposal.ts
@@ -80,10 +80,10 @@ async function sendTokenAddProposal(api: ApiPromise) {
 		Evm: 5001,
 	});
 	const kind = api.createType(
-		'DkgRuntimePrimitivesProposalProposalKind',
+		'WebbProposalsProposalProposalKind',
 		'TokenAdd'
 	);
-	const proposal = api.createType('DkgRuntimePrimitivesProposal', {
+	const proposal = api.createType('WebbProposalsProposal', {
 		Unsigned: {
 			kind: kind,
 			data: prop,

--- a/dkg-test-suite/src/evm/token/testTokenRemoveProposal.ts
+++ b/dkg-test-suite/src/evm/token/testTokenRemoveProposal.ts
@@ -80,10 +80,10 @@ async function sendTokenRemoveProposal(api: ApiPromise) {
 		Evm: 5001,
 	});
 	const kind = api.createType(
-		'DkgRuntimePrimitivesProposalProposalKind',
+		'WebbProposalsProposalProposalKind',
 		'TokenRemove'
 	);
-	const proposal = api.createType('DkgRuntimePrimitivesProposal', {
+	const proposal = api.createType('WebbProposalsProposal', {
 		Unsigned: {
 			kind: kind,
 			data: prop,

--- a/dkg-test-suite/src/evm/v-anchor-configurable-limit/testMaxDepositLimitUpdateProposal.ts
+++ b/dkg-test-suite/src/evm/v-anchor-configurable-limit/testMaxDepositLimitUpdateProposal.ts
@@ -83,10 +83,10 @@ async function sendMaxDepositLimitUpdateProposal(api: ApiPromise) {
 		Evm: 5001,
 	});
 	const kind = api.createType(
-		'DkgRuntimePrimitivesProposalProposalKind',
+		'WebbProposalsProposalProposalKind',
 		'MaxDepositLimitUpdate'
 	);
-	const proposal = api.createType('DkgRuntimePrimitivesProposal', {
+	const proposal = api.createType('WebbProposalsProposal', {
 		Unsigned: {
 			kind: kind,
 			data: prop,

--- a/dkg-test-suite/src/evm/v-anchor-configurable-limit/testMinWithdrawalLimitUpdateProposal.ts
+++ b/dkg-test-suite/src/evm/v-anchor-configurable-limit/testMinWithdrawalLimitUpdateProposal.ts
@@ -85,10 +85,10 @@ async function sendMinWithdrawalLimitUpdateProposal(api: ApiPromise) {
 		Evm: 5001,
 	});
 	const kind = api.createType(
-		'DkgRuntimePrimitivesProposalProposalKind',
+		'WebbProposalsProposalProposalKind',
 		'MinWithdrawalLimitUpdate'
 	);
-	const proposal = api.createType('DkgRuntimePrimitivesProposal', {
+	const proposal = api.createType('WebbProposalsProposal', {
 		Unsigned: {
 			kind: kind,
 			data: prop,

--- a/dkg-test-suite/src/substrate/testAnchorCreateProposal.ts
+++ b/dkg-test-suite/src/substrate/testAnchorCreateProposal.ts
@@ -88,10 +88,10 @@ async function sendAnchorCreateProposal(api: ApiPromise) {
 		SUBSTRATE: 5001,
 	});
 	const kind = api.createType(
-		'DkgRuntimePrimitivesProposalProposalKind',
+		'WebbProposalsProposalProposalKind',
 		'AnchorCreate'
 	);
-	const proposal = api.createType('DkgRuntimePrimitivesProposal', {
+	const proposal = api.createType('WebbProposalsProposal', {
 		Unsigned: {
 			kind: kind,
 			data: prop,

--- a/dkg-test-suite/src/substrate/testAnchorUpdateProposal.ts
+++ b/dkg-test-suite/src/substrate/testAnchorUpdateProposal.ts
@@ -88,10 +88,10 @@ async function sendAnchorUpdateProposal(api: ApiPromise) {
 		SUBSTRATE: 5001,
 	});
 	const kind = api.createType(
-		'DkgRuntimePrimitivesProposalProposalKind',
+		'WebbProposalsProposalProposalKind',
 		'AnchorUpdate'
 	);
-	const proposal = api.createType('DkgRuntimePrimitivesProposal', {
+	const proposal = api.createType('WebbProposalsProposal', {
 		Unsigned: {
 			kind: kind,
 			data: prop,

--- a/dkg-test-suite/src/substrate/testResourceIdUpdateProposal.ts
+++ b/dkg-test-suite/src/substrate/testResourceIdUpdateProposal.ts
@@ -85,10 +85,10 @@ async function sendResourceIdUpdateProposal(api: ApiPromise) {
 		SUBSTRATE: 5001,
 	});
 	const kind = api.createType(
-		'DkgRuntimePrimitivesProposalProposalKind',
+		'WebbProposalsProposalProposalKind',
 		'ResourceIdUpdate'
 	);
-	const proposal = api.createType('DkgRuntimePrimitivesProposal', {
+	const proposal = api.createType('WebbProposalsProposal', {
 		Unsigned: {
 			kind: kind,
 			data: prop,

--- a/dkg-test-suite/src/substrate/testWrappingFeeUpdateProposal.ts
+++ b/dkg-test-suite/src/substrate/testWrappingFeeUpdateProposal.ts
@@ -87,10 +87,10 @@ async function sendWrappingFeeUpdateProposal(api: ApiPromise) {
 		SUBSTRATE: 5001,
 	});
 	const kind = api.createType(
-		'DkgRuntimePrimitivesProposalProposalKind',
+		'WebbProposalsProposalProposalKind',
 		'WrappingFeeUpdate'
 	);
-	const proposal = api.createType('DkgRuntimePrimitivesProposal', {
+	const proposal = api.createType('WebbProposalsProposal', {
 		Unsigned: {
 			kind: kind,
 			data: prop,

--- a/dkg-test-suite/src/substrate/token/testTokenAddProposal.ts
+++ b/dkg-test-suite/src/substrate/token/testTokenAddProposal.ts
@@ -88,10 +88,10 @@ async function sendTokenAddProposal(api: ApiPromise) {
 		SUBSTRATE: 5001,
 	});
 	const kind = api.createType(
-		'DkgRuntimePrimitivesProposalProposalKind',
+		'WebbProposalsProposalProposalKind',
 		'TokenAdd'
 	);
-	const proposal = api.createType('DkgRuntimePrimitivesProposal', {
+	const proposal = api.createType('WebbProposalsProposal', {
 		Unsigned: {
 			kind: kind,
 			data: prop,

--- a/dkg-test-suite/src/substrate/token/testTokenRemoveProposal.ts
+++ b/dkg-test-suite/src/substrate/token/testTokenRemoveProposal.ts
@@ -86,10 +86,10 @@ async function sendTokenRemoveProposal(api: ApiPromise) {
 		SUBSTRATE: 5001,
 	});
 	const kind = api.createType(
-		'DkgRuntimePrimitivesProposalProposalKind',
+		'WebbProposalsProposalProposalKind',
 		'TokenRemove'
 	);
-	const proposal = api.createType('DkgRuntimePrimitivesProposal', {
+	const proposal = api.createType('WebbProposalsProposal', {
 		Unsigned: {
 			kind: kind,
 			data: prop,

--- a/dkg-test-suite/tests/maxDepositLimitProposal.test.ts
+++ b/dkg-test-suite/tests/maxDepositLimitProposal.test.ts
@@ -67,11 +67,11 @@ it('should be able to update max deposit limit', async () => {
 		}
 	);
 	const kind = polkadotApi.createType(
-		'DkgRuntimePrimitivesProposalProposalKind',
+		'WebbProposalsProposalProposalKind',
 		'MaxDepositLimitUpdate'
 	);
 	const maxDepositLimitProposal = polkadotApi.createType(
-		'DkgRuntimePrimitivesProposal',
+		'WebbProposalsProposal',
 		{
 			Unsigned: {
 				kind: kind,
@@ -100,7 +100,7 @@ it('should be able to update max deposit limit', async () => {
 	);
 	const value = new Option(
 		polkadotApi.registry,
-		'DkgRuntimePrimitivesProposal',
+		'WebbProposalsProposal',
 		proposal
 	);
 	expect(value.isSome).to.eq(true);

--- a/dkg-test-suite/tests/minWithdrawalLimit.test.ts
+++ b/dkg-test-suite/tests/minWithdrawalLimit.test.ts
@@ -73,15 +73,11 @@ it('should be able to update min withdrawal limit', async () => {
 			Evm: localChain.chainId,
 		}
 	);
-	const kind = polkadotApi.createType(
-		'DkgRuntimePrimitivesProposalProposalKind',
-		'MinWithdrawalLimitUpdate'
-	);
 	const minWithdrawalLimitProposal = polkadotApi.createType(
-		'DkgRuntimePrimitivesProposal',
+		'WebbProposalsProposal',
 		{
 			Unsigned: {
-				kind: kind,
+				kind: 'MinWithdrawalLimitUpdate',
 				data: prop,
 			},
 		}
@@ -107,7 +103,7 @@ it('should be able to update min withdrawal limit', async () => {
 	);
 	const value = new Option(
 		polkadotApi.registry,
-		'DkgRuntimePrimitivesProposal',
+		'WebbProposalsProposal',
 		proposal
 	);
 	expect(value.isSome).to.eq(true);

--- a/dkg-test-suite/tests/proposerSetUpdateProposal.test.ts
+++ b/dkg-test-suite/tests/proposerSetUpdateProposal.test.ts
@@ -54,7 +54,7 @@ it.skip('proposer set update test', async () => {
 	);
 	const value = new Option(
 		polkadotApi.registry,
-		'DkgRuntimePrimitivesProposal',
+		'WebbProposalsProposal',
 		proposal
 	);
 	expect(value.isSome).to.eq(true);

--- a/dkg-test-suite/tests/rescueTokensProposal.test.ts
+++ b/dkg-test-suite/tests/rescueTokensProposal.test.ts
@@ -91,15 +91,11 @@ it('should be able to sign and execute rescue token proposal', async () => {
 
 		const proposalBytes = encodeWrappingFeeUpdateProposal(proposalPayload);
 		const prop = u8aToHex(proposalBytes);
-		const kind = polkadotApi.createType(
-			'DkgRuntimePrimitivesProposalProposalKind',
-			'WrappingFeeUpdate'
-		);
 		const wrappingFeeUpdateProposal = polkadotApi.createType(
-			'DkgRuntimePrimitivesProposal',
+			'WebbProposalsProposal',
 			{
 				Unsigned: {
-					kind: kind,
+					kind: 'WrappingFeeUpdate',
 					data: prop,
 				},
 			}
@@ -125,7 +121,7 @@ it('should be able to sign and execute rescue token proposal', async () => {
 		);
 		const value = new Option(
 			polkadotApi.registry,
-			'DkgRuntimePrimitivesProposal',
+			'WebbProposalsProposal',
 			proposal
 		);
 		expect(value.isSome).to.eq(true);
@@ -218,15 +214,11 @@ it('should be able to sign and execute rescue token proposal', async () => {
 		};
 		const proposalBytes = encodeRescueTokensProposal(proposalPayload);
 		const prop = u8aToHex(proposalBytes);
-		const kind = polkadotApi.createType(
-			'DkgRuntimePrimitivesProposalProposalKind',
-			'RescueTokens'
-		);
 		const rescueTokensProposal = polkadotApi.createType(
-			'DkgRuntimePrimitivesProposal',
+			'WebbProposalsProposal',
 			{
 				Unsigned: {
-					kind: kind,
+					kind: 'RescueTokens',
 					data: prop,
 				},
 			}
@@ -252,7 +244,7 @@ it('should be able to sign and execute rescue token proposal', async () => {
 		);
 		const value = new Option(
 			polkadotApi.registry,
-			'DkgRuntimePrimitivesProposal',
+			'WebbProposalsProposal',
 			proposal
 		);
 		expect(value.isSome).to.eq(true);

--- a/dkg-test-suite/tests/resourceIdUpdateProposal.test.ts
+++ b/dkg-test-suite/tests/resourceIdUpdateProposal.test.ts
@@ -94,15 +94,11 @@ it('should be able to sign resource id update proposal', async () => {
 			Evm: localChain.chainId,
 		}
 	);
-	const kind = polkadotApi.createType(
-		'DkgRuntimePrimitivesProposalProposalKind',
-		'ResourceIdUpdate'
-	);
 	const resourceIdUpdateProposal = polkadotApi.createType(
-		'DkgRuntimePrimitivesProposal',
+		'WebbProposalsProposal',
 		{
 			Unsigned: {
-				kind: kind,
+				kind: 'ResourceIdUpdate',
 				data: prop,
 			},
 		}
@@ -128,7 +124,7 @@ it('should be able to sign resource id update proposal', async () => {
 	);
 	const value = new Option(
 		polkadotApi.registry,
-		'DkgRuntimePrimitivesProposal',
+		'WebbProposalsProposal',
 		proposal
 	);
 	expect(value.isSome).to.eq(true);

--- a/dkg-test-suite/tests/tokenUpdateProposal.test.ts
+++ b/dkg-test-suite/tests/tokenUpdateProposal.test.ts
@@ -92,15 +92,11 @@ it('should be able to sign token add & remove proposal', async () => {
 				Evm: localChain.chainId,
 			}
 		);
-		const kind = polkadotApi.createType(
-			'DkgRuntimePrimitivesProposalProposalKind',
-			'TokenAdd'
-		);
 		const tokenAddProposal = polkadotApi.createType(
-			'DkgRuntimePrimitivesProposal',
+			'WebbProposalsProposal',
 			{
 				Unsigned: {
-					kind: kind,
+					kind: 'TokenAdd',
 					data: prop,
 				},
 			}
@@ -126,7 +122,7 @@ it('should be able to sign token add & remove proposal', async () => {
 		);
 		const value = new Option(
 			polkadotApi.registry,
-			'DkgRuntimePrimitivesProposal',
+			'WebbProposalsProposal',
 			proposal
 		);
 		expect(value.isSome).to.eq(true);
@@ -188,15 +184,11 @@ it('should be able to sign token add & remove proposal', async () => {
 			Evm: localChain.chainId,
 		}
 	);
-	const kind = polkadotApi.createType(
-		'DkgRuntimePrimitivesProposalProposalKind',
-		'TokenRemove'
-	);
 	const tokenRemoveProposal = polkadotApi.createType(
-		'DkgRuntimePrimitivesProposal',
+		'WebbProposalsProposal',
 		{
 			Unsigned: {
-				kind: kind,
+				kind: 'TokenRemove',
 				data: prop,
 			},
 		}
@@ -222,7 +214,7 @@ it('should be able to sign token add & remove proposal', async () => {
 	);
 	const value = new Option(
 		polkadotApi.registry,
-		'DkgRuntimePrimitivesProposal',
+		'WebbProposalsProposal',
 		proposal
 	);
 

--- a/dkg-test-suite/tests/updateAnchorProposal.test.ts
+++ b/dkg-test-suite/tests/updateAnchorProposal.test.ts
@@ -139,7 +139,7 @@ it('should be able to sign anchor update proposal', async () => {
 	);
 	const value = new Option(
 		polkadotApi.registry,
-		'DkgRuntimePrimitivesProposal',
+		'WebbProposalsProposal',
 		proposal
 	);
 	expect(value.isSome).to.eq(true);

--- a/dkg-test-suite/tests/wrappingFeeUpdateProposal.test.ts
+++ b/dkg-test-suite/tests/wrappingFeeUpdateProposal.test.ts
@@ -79,15 +79,11 @@ it('should be able to sign wrapping fee update proposal', async () => {
 			Evm: localChain.chainId,
 		}
 	);
-	const kind = polkadotApi.createType(
-		'DkgRuntimePrimitivesProposalProposalKind',
-		'WrappingFeeUpdate'
-	);
 	const wrappingFeeUpdateProposal = polkadotApi.createType(
-		'DkgRuntimePrimitivesProposal',
+		'WebbProposalsProposal',
 		{
 			Unsigned: {
-				kind: kind,
+				kind: 'WrappingFeeUpdate',
 				data: prop,
 			},
 		}
@@ -111,7 +107,7 @@ it('should be able to sign wrapping fee update proposal', async () => {
 	);
 	const value = new Option(
 		polkadotApi.registry,
-		'DkgRuntimePrimitivesProposal',
+		'WebbProposalsProposal',
 		proposal
 	);
 	expect(value.isSome).to.eq(true);

--- a/pallets/dkg-proposal-handler/Cargo.toml
+++ b/pallets/dkg-proposal-handler/Cargo.toml
@@ -27,6 +27,8 @@ sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-
 pallet-dkg-metadata = { path = "../dkg-metadata", default-features = false }
 hex-literal = { version = "0.3", optional = true }
 
+webb-proposals = { version = "0.4.3", default-features = false }
+
 [dev-dependencies]
 pallet-dkg-proposals = { path = "../dkg-proposals"}
 serde = { version = "1.0.119" }
@@ -60,4 +62,5 @@ std = [
 	"frame-benchmarking/std",
 	"dkg-runtime-primitives/std",
 	"pallet-dkg-metadata/std",
+	"webb-proposals/std",
 ]

--- a/pallets/dkg-proposal-handler/Cargo.toml
+++ b/pallets/dkg-proposal-handler/Cargo.toml
@@ -27,7 +27,7 @@ sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-
 pallet-dkg-metadata = { path = "../dkg-metadata", default-features = false }
 hex-literal = { version = "0.3", optional = true }
 
-webb-proposals = { version = "0.4.3", default-features = false }
+webb-proposals = { version = "0.4.4", default-features = false }
 
 [dev-dependencies]
 pallet-dkg-proposals = { path = "../dkg-proposals"}

--- a/pallets/dkg-proposal-handler/src/benchmarking.rs
+++ b/pallets/dkg-proposal-handler/src/benchmarking.rs
@@ -25,9 +25,8 @@ use sp_core::{ecdsa, H256, U256};
 use sp_io::crypto::{ecdsa_generate, ecdsa_sign_prehashed};
 use sp_std::vec::Vec;
 
-use dkg_runtime_primitives::{
-	keccak_256, EIP2930Transaction, Proposal, ProposalKind, TransactionAction, TransactionV2,
-};
+use dkg_runtime_primitives::{keccak_256, EIP2930Transaction, TransactionAction, TransactionV2};
+use webb_proposals::{Proposal, ProposalKind};
 
 pub fn mock_eth_tx_eip2930(nonce: u8) -> EIP2930Transaction {
 	EIP2930Transaction {

--- a/pallets/dkg-proposal-handler/src/lib.rs
+++ b/pallets/dkg-proposal-handler/src/lib.rs
@@ -119,8 +119,8 @@ mod tests;
 
 use dkg_runtime_primitives::{
 	offchain::storage_keys::{OFFCHAIN_SIGNED_PROPOSALS, SUBMIT_SIGNED_PROPOSAL_ON_CHAIN_LOCK},
-	DKGPayloadKey, OffchainSignedProposals, Proposal, ProposalAction, ProposalHandlerTrait,
-	ProposalKind, StoredUnsignedProposal, TypedChainId,
+	DKGPayloadKey, OffchainSignedProposals, ProposalAction, ProposalHandlerTrait,
+	StoredUnsignedProposal, TypedChainId,
 };
 use frame_support::pallet_prelude::*;
 use frame_system::{
@@ -135,6 +135,7 @@ use sp_runtime::{
 	traits::Saturating,
 };
 use sp_std::vec::Vec;
+use webb_proposals::{OnSignedProposal, Proposal, ProposalKind};
 
 pub mod weights;
 pub use weights::WeightInfo;
@@ -145,12 +146,11 @@ mod benchmarking;
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use dkg_runtime_primitives::{
-		utils::ensure_signed_by_dkg, DKGPayloadKey, Proposal, ProposalKind,
-	};
-	use frame_support::dispatch::DispatchResultWithPostInfo;
+	use dkg_runtime_primitives::{utils::ensure_signed_by_dkg, DKGPayloadKey};
+	use frame_support::dispatch::{DispatchError, DispatchResultWithPostInfo};
 	use frame_system::{offchain::CreateSignedTransaction, pallet_prelude::*};
 	use sp_runtime::traits::{CheckedSub, One, Zero};
+	use webb_proposals::{Proposal, ProposalKind};
 
 	/// Unsigned proposal for this pallet
 	pub type StoredUnsignedProposalOf<T> =
@@ -165,6 +165,8 @@ pub mod pallet {
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 		/// The identifier type for an offchain worker.
 		type OffChainAuthId: AppCrypto<Self::Public, Self::Signature>;
+		/// The signed proposal handler trait
+		type SignedProposalHandler: OnSignedProposal<DispatchError>;
 		/// Max number of signed proposal submissions per batch;
 		#[pallet::constant]
 		type MaxSubmissionsPerBatch: Get<u16>;
@@ -519,7 +521,7 @@ impl<T: Config> ProposalHandlerTrait for Pallet<T> {
 			"submit_signed_proposal: signature is valid"
 		);
 		// Update storage
-		SignedProposals::<T>::insert(id.typed_chain_id, id.key, prop);
+		SignedProposals::<T>::insert(id.typed_chain_id, id.key, prop.clone());
 		UnsignedProposalQueue::<T>::remove(id.typed_chain_id, id.key);
 		// Emit event so frontend can react to it.
 		Self::deposit_event(Event::<T>::ProposalSigned {
@@ -528,7 +530,8 @@ impl<T: Config> ProposalHandlerTrait for Pallet<T> {
 			data: data.to_vec(),
 			signature: sig.to_vec(),
 		});
-
+		// Finally let any handlers handle the signed proposal
+		T::SignedProposalHandler::on_signed_proposal(prop)?;
 		Ok(())
 	}
 }

--- a/pallets/dkg-proposal-handler/src/lib.rs
+++ b/pallets/dkg-proposal-handler/src/lib.rs
@@ -338,7 +338,7 @@ pub mod pallet {
 							// this is a bad signature.
 							// we emit it as an event.
 							Self::deposit_event(Event::InvalidProposalSignature {
-								kind: kind.clone(),
+								kind: *kind,
 								data: data.clone(),
 								expected_public_key: e.expected_public_key(),
 								actual_public_key: e.actual_public_key(),

--- a/pallets/dkg-proposal-handler/src/mock.rs
+++ b/pallets/dkg-proposal-handler/src/mock.rs
@@ -167,6 +167,7 @@ impl pallet_dkg_proposal_handler::Config for Test {
 	type OffChainAuthId = dkg_runtime_primitives::offchain::crypto::OffchainAuthId;
 	type MaxSubmissionsPerBatch = frame_support::traits::ConstU16<100>;
 	type UnsignedProposalExpiry = frame_support::traits::ConstU64<10>;
+	type SignedProposalHandler = ();
 	type WeightInfo = ();
 }
 

--- a/pallets/dkg-proposal-handler/src/mock.rs
+++ b/pallets/dkg-proposal-handler/src/mock.rs
@@ -37,10 +37,10 @@ use sp_runtime::RuntimeAppPublic;
 use dkg_runtime_primitives::{keccak_256, TransactionV2, TypedChainId};
 
 use dkg_runtime_primitives::{
-	crypto::AuthorityId as DKGId, EIP2930Transaction, Proposal, ProposalKind, TransactionAction,
-	U256,
+	crypto::AuthorityId as DKGId, EIP2930Transaction, TransactionAction, U256,
 };
 use std::sync::Arc;
+use webb_proposals::{Proposal, ProposalKind};
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;

--- a/pallets/dkg-proposal-handler/src/tests.rs
+++ b/pallets/dkg-proposal-handler/src/tests.rs
@@ -25,11 +25,11 @@ use sp_std::vec::Vec;
 use super::mock::DKGProposalHandler;
 use dkg_runtime_primitives::{
 	offchain::storage_keys::OFFCHAIN_SIGNED_PROPOSALS, DKGPayloadKey, OffchainSignedProposals,
-	Proposal, ProposalAction, ProposalHandlerTrait, ProposalHeader, ProposalKind, TransactionV2,
-	TypedChainId,
+	ProposalAction, ProposalHandlerTrait, ProposalHeader, TransactionV2, TypedChainId,
 };
 use sp_core::sr25519;
 use sp_runtime::offchain::storage::MutateStorageError;
+use webb_proposals::{Proposal, ProposalKind};
 
 // *** Utility ***
 

--- a/pallets/dkg-proposals/Cargo.toml
+++ b/pallets/dkg-proposals/Cargo.toml
@@ -34,6 +34,7 @@ frame-system-benchmarking = { default-features = false, git = "https://github.co
 frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26", optional = true }
 
 [dev-dependencies]
+webb-proposals = { version = "0.4.3", default-features = false, features = ["scale", "evm", "substrate"] }
 pallet-dkg-proposal-handler = { path = "../dkg-proposal-handler" }
 pallet-dkg-metadata = { path = "../dkg-metadata" }
 pallet-collator-selection = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.26" }

--- a/pallets/dkg-proposals/Cargo.toml
+++ b/pallets/dkg-proposals/Cargo.toml
@@ -34,7 +34,7 @@ frame-system-benchmarking = { default-features = false, git = "https://github.co
 frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26", optional = true }
 
 [dev-dependencies]
-webb-proposals = { version = "0.4.3", default-features = false, features = ["scale", "evm", "substrate"] }
+webb-proposals = { version = "0.4.4", default-features = false, features = ["scale", "evm", "substrate"] }
 pallet-dkg-proposal-handler = { path = "../dkg-proposal-handler" }
 pallet-dkg-metadata = { path = "../dkg-metadata" }
 pallet-collator-selection = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.26" }

--- a/pallets/dkg-proposals/src/mock.rs
+++ b/pallets/dkg-proposals/src/mock.rs
@@ -241,6 +241,7 @@ impl pallet_dkg_proposal_handler::Config for Test {
 	type OffChainAuthId = dkg_runtime_primitives::offchain::crypto::OffchainAuthId;
 	type MaxSubmissionsPerBatch = frame_support::traits::ConstU16<100>;
 	type UnsignedProposalExpiry = frame_support::traits::ConstU64<10>;
+	type SignedProposalHandler = ();
 	type WeightInfo = ();
 }
 

--- a/pallets/dkg-proposals/src/tests.rs
+++ b/pallets/dkg-proposals/src/tests.rs
@@ -29,11 +29,11 @@ use crate::mock::{
 use codec::Encode;
 use core::panic;
 use dkg_runtime_primitives::{
-	DKGPayloadKey, FunctionSignature, Proposal, ProposalHeader, ProposalKind, ProposalNonce,
-	TypedChainId,
+	DKGPayloadKey, FunctionSignature, ProposalHeader, ProposalNonce, TypedChainId,
 };
 use frame_support::{assert_err, assert_noop, assert_ok};
 use std::vec;
+use webb_proposals::{Proposal, ProposalKind};
 
 use crate as pallet_dkg_proposals;
 

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -591,6 +591,7 @@ impl pallet_dkg_proposal_handler::Config for Runtime {
 	type OffChainAuthId = dkg_runtime_primitives::offchain::crypto::OffchainAuthId;
 	type MaxSubmissionsPerBatch = frame_support::traits::ConstU16<100>;
 	type UnsignedProposalExpiry = UnsignedProposalExpiry;
+	type SignedProposalHandler = ();
 	type WeightInfo = pallet_dkg_proposal_handler::weights::WebbWeight<Runtime>;
 }
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Adds the on signed proposal handler that can call into other pallets that implement it.
- Updates webb proposals versions and moves some of proposal utilities into the `webb-proposals` repo.

