### PR TITLE
Add pub key to sig event

### DIFF
--- a/pallets/dkg-metadata/src/lib.rs
+++ b/pallets/dkg-metadata/src/lib.rs
@@ -94,15 +94,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Decode, Encode};
-
-use frame_support::{
-	dispatch::DispatchResultWithPostInfo,
-	traits::{EstimateNextSessionRotation, Get, OneSessionHandler},
-	Parameter,
-};
-use frame_system::offchain::{SendSignedTransaction, Signer};
-use sp_std::convert::{TryFrom, TryInto};
-
 use dkg_runtime_primitives::{
 	offchain::storage_keys::{
 		AGGREGATED_MISBEHAVIOUR_REPORTS, AGGREGATED_MISBEHAVIOUR_REPORTS_LOCK,
@@ -116,6 +107,13 @@ use dkg_runtime_primitives::{
 	AggregatedMisbehaviourReports, AggregatedPublicKeys, AuthorityIndex, AuthoritySet,
 	ConsensusLog, MisbehaviourType, RefreshProposal, RefreshProposalSigned, DKG_ENGINE_ID,
 };
+use frame_support::{
+	dispatch::DispatchResultWithPostInfo,
+	traits::{EstimateNextSessionRotation, Get, OneSessionHandler},
+	Parameter,
+};
+use frame_system::offchain::{SendSignedTransaction, Signer};
+pub use pallet::*;
 use sp_runtime::{
 	generic::DigestItem,
 	offchain::{
@@ -125,13 +123,17 @@ use sp_runtime::{
 	traits::{AtLeast32BitUnsigned, Convert, IsMember, Member, Saturating},
 	DispatchError, Permill, RuntimeAppPublic,
 };
-use sp_std::{collections::btree_map::BTreeMap, prelude::*};
-
-pub mod types;
+use sp_std::{
+	collections::btree_map::BTreeMap,
+	convert::{TryFrom, TryInto},
+	prelude::*,
+};
 use types::RoundMetadata;
+use weights::WeightInfo;
 
 #[cfg(test)]
 mod mock;
+pub mod types;
 
 #[cfg(test)]
 mod tests;
@@ -140,13 +142,9 @@ mod tests;
 mod benchmarking;
 
 pub mod weights;
-use weights::WeightInfo;
-
-pub use pallet::*;
 
 #[frame_support::pallet]
 pub mod pallet {
-	use super::*;
 	use dkg_runtime_primitives::{traits::OnDKGPublicKeyChangeHandler, ProposalHandlerTrait};
 	use frame_support::{ensure, pallet_prelude::*, transactional};
 	use frame_system::{
@@ -155,6 +153,8 @@ pub mod pallet {
 		pallet_prelude::*,
 	};
 	use sp_runtime::{Percent, Permill};
+
+	use super::*;
 
 	/// A `Convert` implementation that finds the stash of the given controller account,
 	/// if any.
@@ -523,11 +523,19 @@ pub mod pallet {
 		/// Next public key submitted
 		NextPublicKeySubmitted { compressed_pub_key: Vec<u8>, uncompressed_pub_key: Vec<u8> },
 		/// Next public key signature submitted
-		NextPublicKeySignatureSubmitted { pub_key_sig: Vec<u8> },
+		NextPublicKeySignatureSubmitted {
+			pub_key_sig: Vec<u8>,
+			compressed_pub_key: Vec<u8>,
+			uncompressed_pub_key: Vec<u8>,
+		},
 		/// Current Public Key Changed.
 		PublicKeyChanged { compressed_pub_key: Vec<u8>, uncompressed_pub_key: Vec<u8> },
 		/// Current Public Key Signature Changed.
-		PublicKeySignatureChanged { pub_key_sig: Vec<u8> },
+		PublicKeySignatureChanged {
+			pub_key_sig: Vec<u8>,
+			compressed_pub_key: Vec<u8>,
+			uncompressed_pub_key: Vec<u8>,
+		},
 		/// Misbehaviour reports submitted
 		MisbehaviourReportsSubmitted {
 			misbehaviour_type: MisbehaviourType,
@@ -795,9 +803,11 @@ pub mod pallet {
 			ensure!(!used_signatures.contains(&signature), Error::<T>::UsedSignature);
 
 			let (_, next_pub_key) = Self::next_dkg_public_key().unwrap();
+			let uncompressed_pub_key =
+				Self::decompress_public_key(next_pub_key.clone()).unwrap_or_default();
 			let data = RefreshProposal {
 				nonce: Self::refresh_nonce().into(),
-				pub_key: Self::decompress_public_key(next_pub_key).unwrap_or_default(),
+				pub_key: uncompressed_pub_key.clone(),
 			};
 			// Verify signature against the `RefreshProposal`
 			dkg_runtime_primitives::utils::ensure_signed_by_dkg::<Self>(&signature, &data.encode())
@@ -816,7 +826,11 @@ pub mod pallet {
 			// Remove unsigned refresh proposal from queue
 			T::ProposalHandler::handle_signed_refresh_proposal(data)?;
 			NextPublicKeySignature::<T>::put(signature.clone());
-			Self::deposit_event(Event::NextPublicKeySignatureSubmitted { pub_key_sig: signature });
+			Self::deposit_event(Event::NextPublicKeySignatureSubmitted {
+				uncompressed_pub_key,
+				compressed_pub_key: next_pub_key,
+				pub_key_sig: signature,
+			});
 			// Handle manual refresh if flag is set
 			if Self::should_manual_refresh() {
 				ShouldManualRefresh::<T>::put(false);
@@ -1334,13 +1348,18 @@ impl<T: Config> Pallet<T> {
 			UsedSignatures::<T>::mutate(|val| {
 				val.push(pub_key_signature.clone());
 			});
+			let uncompressed_pub_key =
+				Self::decompress_public_key(next_pub_key.1.clone()).unwrap_or_default();
+			let compressed_pub_key = next_pub_key.1;
+
 			// Emit events so other front-end know that.
 			Self::deposit_event(Event::PublicKeyChanged {
-				uncompressed_pub_key: Self::decompress_public_key(next_pub_key.1.clone())
-					.unwrap_or_default(),
-				compressed_pub_key: next_pub_key.1,
+				uncompressed_pub_key: uncompressed_pub_key.clone(),
+				compressed_pub_key: compressed_pub_key.clone(),
 			});
 			Self::deposit_event(Event::PublicKeySignatureChanged {
+				uncompressed_pub_key,
+				compressed_pub_key,
 				pub_key_sig: next_pub_key_signature,
 			});
 		}

--- a/scripts/run-archive-local-net.sh
+++ b/scripts/run-archive-local-net.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 
-RUST_LOG=dkg=trace ./target/release/dkg-standalone-node   --tmp --alice   --pruning=archive --rpc-cors=all &
-RUST_LOG=dkg=trace ./target/release/dkg-standalone-node   --tmp --bob --pruning=archive --rpc-cors=all &
-RUST_LOG=dkg=trace ./target/release/dkg-standalone-node  --tmp --charlie --pruning=archive --rpc-cors=all &
+RUST_LOG=dkg=trace ./target/release/dkg-standalone-node  --base-path=./tmp/alice  --alice   --pruning=archive --rpc-cors=all &
+RUST_LOG=dkg=trace ./target/release/dkg-standalone-node  --base-path=./tmp/bob  --bob --pruning=archive --rpc-cors=all &
+RUST_LOG=dkg=trace ./target/release/dkg-standalone-node  --base-path=./tmp/charlie --charlie --pruning=archive --rpc-cors=all &


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Fix the `--tmp` flag for the archive node script
- Added compressed keys to the sig events in order for the client to track the progress of keys generation, signature, and change


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 
