### PR TITLE
[fix] update estimate session to new session change logic

### DIFF
--- a/dkg-gadget/src/worker.rs
+++ b/dkg-gadget/src/worker.rs
@@ -94,7 +94,7 @@ pub const MAX_SUBMISSION_DELAY: u32 = 3;
 
 pub const MAX_SIGNING_SETS: u64 = 16;
 
-pub const SESSION_PROGRESS_THRESHOLD: sp_runtime::Permill = sp_runtime::Permill::from_percent(60);
+pub const SESSION_PROGRESS_THRESHOLD: sp_runtime::Permill = sp_runtime::Permill::from_percent(90);
 
 pub type Shared<T> = Arc<RwLock<T>>;
 

--- a/parachain/runtime/rococo/src/lib.rs
+++ b/parachain/runtime/rococo/src/lib.rs
@@ -442,7 +442,7 @@ parameter_types! {
 impl pallet_session::Config for Runtime {
 	type Event = Event;
 	type Keys = SessionKeys;
-	type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
+	type NextSessionRotation = pallet_dkg_metadata::DKGPeriodicSessions<Period, Offset, Runtime>;
 	// Essentially just Aura, but lets be pedantic.
 	type SessionHandler = <SessionKeys as sp_runtime::traits::OpaqueKeys>::KeyTypeIdProviders;
 	type SessionManager = CollatorSelection;

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -298,7 +298,7 @@ parameter_types! {
 #[cfg(not(feature = "integration-tests"))]
 parameter_types! {
   // How often we trigger a new session.
-  pub const Period: BlockNumber = MINUTES;
+  pub const Period: BlockNumber = 10 * MINUTES;
   pub const Offset: BlockNumber = 0;
 }
 
@@ -307,7 +307,7 @@ impl pallet_session::Config for Runtime {
 	type ValidatorId = <Self as frame_system::Config>::AccountId;
 	type ValidatorIdOf = pallet_staking::StashOf<Self>;
 	type ShouldEndSession = pallet_dkg_metadata::DKGPeriodicSessions<Period, Offset, Runtime>;
-	type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
+	type NextSessionRotation = pallet_dkg_metadata::DKGPeriodicSessions<Period, Offset, Runtime>;
 	type SessionManager = Staking;
 	type SessionHandler = <opaque::SessionKeys as OpaqueKeys>::KeyTypeIdProviders;
 	type Keys = opaque::SessionKeys;


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- The [default](https://github.com/paritytech/substrate/blob/4a5a9dea00c9b4e4d34ff56368451aa4dac09d77/frame/session/src/lib.rs#L178) `estimate_current_session_progress ` function assumes that session is rotated every period, this is not true in our case since our rotation is depended on dkg key upload, so when we have crossed the threshold of the session period this function returns the wrong values 
```
Example :
Period = 10blocks
Current = 12blocks
The function returns 20% session progress, but in our case it is really 120% since we didnt rotate
```
This function is modified to check if we did actually perform a rotation, if we did, then revert to previous logic, else return 100%
- Change rotation threshold to 90% this reduces occurence of https://github.com/webb-tools/dkg-substrate/issues/407 error


**Reference issue to close (if applicable)**
Closes #405, the root cause of this error is that the refreshProposal was not correctly triggered, this happened since refreshProposal depends on `estimate_current_session_progress ` https://github.com/webb-tools/dkg-substrate/blob/abc180db3ffa46b85d00128957f1f66a7ad23416/pallets/dkg-metadata/src/lib.rs#L1737
