### PR TITLE
[TASK] Track session rotation period from the start of the last session

### DIFF
--- a/pallets/dkg-metadata/src/lib.rs
+++ b/pallets/dkg-metadata/src/lib.rs
@@ -110,7 +110,7 @@ use dkg_runtime_primitives::{
 use frame_support::{
 	dispatch::DispatchResultWithPostInfo,
 	pallet_prelude::{Get, Weight},
-	traits::{EstimateNextSessionRotation, OneSessionHandler, ValidatorSet},
+	traits::{EstimateNextSessionRotation, OneSessionHandler},
 };
 use frame_system::offchain::{SendSignedTransaction, Signer};
 pub use pallet::*;


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Store the last rotated block and use as base for next calculation

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #424
