### PR TITLE
[PATCH] Refactor the Inner `AsyncProtocol` to avoid tasks race

### DIFF
--- a/dkg-gadget/src/async_protocols/keygen/handler.rs
+++ b/dkg-gadget/src/async_protocols/keygen/handler.rs
@@ -27,16 +27,16 @@ use std::fmt::Debug;
 use dkg_primitives::types::{DKGError, DKGMsgStatus};
 use futures::FutureExt;
 
-impl<'a, Out: Send + Debug + 'a> GenericAsyncHandler<'a, Out>
+impl<Out: Send + Debug + 'static> GenericAsyncHandler<'static, Out>
 where
 	(): Extend<Out>,
 {
 	/// Top-level function used to begin the execution of async protocols
-	pub fn setup_keygen<BI: BlockchainInterface + 'a>(
+	pub fn setup_keygen<BI: BlockchainInterface + 'static>(
 		params: AsyncProtocolParameters<BI>,
 		threshold: u16,
 		status: DKGMsgStatus,
-	) -> Result<GenericAsyncHandler<'a, ()>, DKGError> {
+	) -> Result<GenericAsyncHandler<'static, ()>, DKGError> {
 		let status_handle = params.handle.clone();
 		let mut stop_rx =
 			status_handle.stop_rx.lock().take().ok_or_else(|| DKGError::GenericError {
@@ -88,14 +88,14 @@ where
 		Ok(GenericAsyncHandler { protocol })
 	}
 
-	fn new_keygen<BI: BlockchainInterface + 'a>(
+	fn new_keygen<BI: BlockchainInterface + 'static>(
 		params: AsyncProtocolParameters<BI>,
 		i: u16,
 		t: u16,
 		n: u16,
 		async_index: u8,
 		status: DKGMsgStatus,
-	) -> Result<GenericAsyncHandler<'a, <Keygen as StateMachineHandler>::Return>, DKGError> {
+	) -> Result<GenericAsyncHandler<'static, <Keygen as StateMachineHandler>::Return>, DKGError> {
 		let ty = match status {
 			DKGMsgStatus::ACTIVE => KeygenRound::ACTIVE,
 			DKGMsgStatus::QUEUED => KeygenRound::QUEUED,

--- a/dkg-gadget/src/async_protocols/keygen/state_machine.rs
+++ b/dkg-gadget/src/async_protocols/keygen/state_machine.rs
@@ -68,7 +68,7 @@ impl StateMachineHandler for Keygen {
 		Ok(())
 	}
 
-	async fn on_finish<BI: BlockchainInterface>(
+	async fn on_finish<BI: BlockchainInterface + 'static>(
 		local_key: <Self as StateMachine>::Output,
 		params: AsyncProtocolParameters<BI>,
 		_: Self::AdditionalReturnParam,

--- a/dkg-gadget/src/async_protocols/mod.rs
+++ b/dkg-gadget/src/async_protocols/mod.rs
@@ -231,14 +231,14 @@ impl<Out> Future for GenericAsyncHandler<'_, Out> {
 	}
 }
 
-pub fn new_inner<'a, SM: StateMachineHandler + 'static, BI: BlockchainInterface + 'a>(
+pub fn new_inner<SM: StateMachineHandler + 'static, BI: BlockchainInterface + 'static>(
 	additional_param: SM::AdditionalReturnParam,
 	sm: SM,
 	params: AsyncProtocolParameters<BI>,
 	channel_type: ProtocolType,
 	async_index: u8,
 	status: DKGMsgStatus,
-) -> Result<GenericAsyncHandler<'a, SM::Return>, DKGError>
+) -> Result<GenericAsyncHandler<'static, SM::Return>, DKGError>
 where
 	<SM as StateMachine>::Err: Send + Debug,
 	<SM as StateMachine>::MessageBody: Send,
@@ -297,27 +297,20 @@ where
 		incoming_tx_proto,
 	);
 
-	// Combine all futures into a concurrent select subroutine
+	// Spawn the 3 tasks
+	// 1. The outbound task (will stop if the protocol finished, after flushing the messages to the
+	// network.)
+	tokio::spawn(outgoing_to_wire);
+	// 2. The inbound task (we will abort that task if the protocol finished)
+	let handle = tokio::spawn(inbound_signed_message_receiver);
+	// 3. The async protocol itself
 	let protocol = async move {
-		let res = tokio::select! {
-			proto_res = async_proto => {
-				log::info!(target: "dkg", "🕸️  Protocol {:?} Ended: {:?}", channel_type.clone(), proto_res);
-				proto_res
-			},
-
-			outgoing_res = outgoing_to_wire => {
-				log::error!(target: "dkg", "🕸️  Outbound Sender Ended: {:?}", outgoing_res);
-				Err(DKGError::GenericError { reason: "Outbound sender ended".to_string() })
-			},
-
-			incoming_res = inbound_signed_message_receiver => {
-				log::error!(target: "dkg", "🕸️  Inbound Receiver Ended: {:?}", incoming_res);
-				Err(DKGError::GenericError { reason: "Incoming receiver ended".to_string() })
-			}
-		};
+		let res = async_proto.await;
+		log::info!(target: "dkg", "🕸️  Protocol {:?} Ended: {:?}", channel_type.clone(), res);
+		// Abort the inbound task
+		handle.abort();
 		res
 	};
-
 	Ok(GenericAsyncHandler { protocol: Box::pin(protocol) })
 }
 
@@ -333,21 +326,38 @@ fn get_party_session_id<'a, BI: BlockchainInterface + 'a>(
 	(party_ind, session_id, id)
 }
 
-fn generate_outgoing_to_wire_fn<'a, SM: StateMachineHandler + 'a, BI: BlockchainInterface + 'a>(
+fn generate_outgoing_to_wire_fn<
+	SM: StateMachineHandler + 'static,
+	BI: BlockchainInterface + 'static,
+>(
 	params: AsyncProtocolParameters<BI>,
-	mut outgoing_rx: UnboundedReceiver<Msg<<SM as StateMachine>::MessageBody>>,
+	outgoing_rx: UnboundedReceiver<Msg<<SM as StateMachine>::MessageBody>>,
 	proto_ty: ProtocolType,
 	async_index: u8,
 	status: DKGMsgStatus,
-) -> impl SendFuture<'a, ()>
+) -> impl SendFuture<'static, ()>
 where
 	<SM as StateMachine>::MessageBody: Serialize,
 	<SM as StateMachine>::MessageBody: Send,
 	<SM as StateMachine>::Output: Send,
 {
 	Box::pin(async move {
+		let mut outgoing_rx = outgoing_rx.fuse();
 		// take all unsigned messages, then sign them and send outbound
-		while let Some(unsigned_message) = outgoing_rx.next().await {
+		loop {
+			// Here is a few explanations about the next few lines:
+			// We wait for a message to be available on the channel, and then we take it.
+			// this return an Option<Msg> which is None if the channel is closed.
+			// the channel could be closed if the protocol is finished, since the last sender is
+			// dropped. hence, we will break the loop and return.
+			let unsigned_message = match outgoing_rx.next().await {
+				Some(msg) => msg,
+				None => {
+					log::debug!(target: "dkg", "🕸️  Outgoing Receiver Ended");
+					break
+				},
+			};
+
 			log::info!(target: "dkg", "Async proto sent outbound request in session={} from={:?} to={:?} | (ty: {:?})", params.session_id, unsigned_message.sender, unsigned_message.receiver, &proto_ty);
 			let party_id = unsigned_message.sender;
 			let serialized_body = match serde_json::to_vec(&unsigned_message) {
@@ -384,23 +394,26 @@ where
 			} else {
 				log::info!(target: "dkg", "🕸️  Async proto sent outbound message: {:?}", &proto_ty);
 			}
-		}
 
-		Err(DKGError::CriticalError {
-			reason: "Outbound stream stopped producing items".to_string(),
-		})
+			// check the status of the async protocol.
+			// if it is complete, or if it has errored, then break out of the loop.
+			if params.handle.is_completed() || params.handle.is_terminated() {
+				log::debug!(target: "dkg", "🕸️  Async proto is completed or terminated, breaking out of incomming loop");
+				break
+			}
+		}
+		Ok(())
 	})
 }
 
 pub fn generate_inbound_signed_message_receiver_fn<
-	'a,
-	SM: StateMachineHandler + 'a,
-	BI: BlockchainInterface + 'a,
+	SM: StateMachineHandler + 'static,
+	BI: BlockchainInterface + 'static,
 >(
 	params: AsyncProtocolParameters<BI>,
 	channel_type: ProtocolType,
 	to_async_proto: UnboundedSender<Msg<<SM as StateMachine>::MessageBody>>,
-) -> impl SendFuture<'a, ()>
+) -> impl SendFuture<'static, ()>
 where
 	<SM as StateMachine>::MessageBody: Send,
 	<SM as StateMachine>::Output: Send,
@@ -408,20 +421,31 @@ where
 	Box::pin(async move {
 		// the below wrapper will map signed messages into unsigned messages
 		let incoming = params.handle.broadcaster.subscribe();
-		let mut incoming_wrapper =
+		let incoming_wrapper =
 			IncomingAsyncProtocolWrapper::new(incoming, channel_type.clone(), &params);
+		let mut incoming_wrapper = incoming_wrapper.fuse();
+		loop {
+			let unsigned_message = match incoming_wrapper.next().await {
+				Some(msg) => msg,
+				None => {
+					log::debug!(target: "dkg", "🕸️  Inbound Receiver Ended");
+					break
+				},
+			};
 
-		while let Some(unsigned_message) = incoming_wrapper.next().await {
 			if SM::handle_unsigned_message(&to_async_proto, unsigned_message, &channel_type)
 				.is_err()
 			{
 				log::error!(target: "dkg", "Error handling unsigned inbound message. Returning");
 				break
 			}
-		}
 
-		Err::<(), _>(DKGError::CriticalError {
-			reason: "Inbound stream stopped producing items".to_string(),
-		})
+			// check the status of the async protocol.
+			if params.handle.is_completed() || params.handle.is_terminated() {
+				log::debug!(target: "dkg", "🕸️  Async proto is completed or terminated, breaking out of inbound loop");
+				break
+			}
+		}
+		Ok(())
 	})
 }

--- a/dkg-gadget/src/async_protocols/remote.rs
+++ b/dkg-gadget/src/async_protocols/remote.rs
@@ -167,13 +167,21 @@ impl<C> AsyncProtocolRemote<C> {
 	}
 
 	pub fn is_keygen_finished(&self) -> bool {
+		self.is_completed()
+	}
+
+	pub fn is_signing_finished(&self) -> bool {
+		self.is_completed()
+	}
+
+	pub fn is_completed(&self) -> bool {
 		let state = self.get_status();
 		matches!(state, MetaHandlerStatus::Complete)
 	}
 
-	pub fn is_signing_finished(&self) -> bool {
+	pub fn is_terminated(&self) -> bool {
 		let state = self.get_status();
-		matches!(state, MetaHandlerStatus::Complete)
+		matches!(state, MetaHandlerStatus::Terminated)
 	}
 
 	pub fn current_round_blame(&self) -> CurrentRoundBlame {

--- a/dkg-gadget/src/async_protocols/sign/handler.rs
+++ b/dkg-gadget/src/async_protocols/sign/handler.rs
@@ -39,18 +39,18 @@ use multi_party_ecdsa::protocols::multi_party_ecdsa::gg_2020::{
 	state_machine::sign::SignError::{CompleteSigning, LocalSigning},
 };
 
-impl<'a, Out: Send + Debug + 'a> GenericAsyncHandler<'a, Out>
+impl<Out: Send + Debug + 'static> GenericAsyncHandler<'static, Out>
 where
 	(): Extend<Out>,
 {
 	/// Top level function for setting up signing
-	pub fn setup_signing<BI: BlockchainInterface + 'a>(
+	pub fn setup_signing<BI: BlockchainInterface + 'static>(
 		params: AsyncProtocolParameters<BI>,
 		threshold: u16,
 		unsigned_proposals: Vec<UnsignedProposal>,
 		signing_set: Vec<u16>,
 		async_index: u8,
-	) -> Result<GenericAsyncHandler<'a, ()>, DKGError> {
+	) -> Result<GenericAsyncHandler<'static, ()>, DKGError> {
 		assert!(
 			threshold + 1 == signing_set.len() as u16,
 			"Signing set must be of size threshold + 1"
@@ -144,7 +144,7 @@ where
 	}
 
 	#[allow(clippy::too_many_arguments)]
-	fn new_offline<BI: BlockchainInterface + 'a>(
+	fn new_offline<BI: BlockchainInterface + 'static>(
 		params: AsyncProtocolParameters<BI>,
 		unsigned_proposal: UnsignedProposal,
 		i: u16,
@@ -153,7 +153,8 @@ where
 		threshold: u16,
 		batch_key: BatchKey,
 		async_index: u8,
-	) -> Result<GenericAsyncHandler<'a, <OfflineStage as StateMachineHandler>::Return>, DKGError> {
+	) -> Result<GenericAsyncHandler<'static, <OfflineStage as StateMachineHandler>::Return>, DKGError>
+	{
 		let channel_type = ProtocolType::Offline {
 			unsigned_proposal: Arc::new(unsigned_proposal.clone()),
 			i,
@@ -173,7 +174,7 @@ where
 	}
 
 	#[allow(clippy::too_many_arguments)]
-	pub(crate) fn new_voting<BI: BlockchainInterface + 'a>(
+	pub(crate) fn new_voting<BI: BlockchainInterface + 'static>(
 		params: AsyncProtocolParameters<BI>,
 		completed_offline_stage: CompletedOfflineStage,
 		unsigned_proposal: UnsignedProposal,
@@ -182,7 +183,7 @@ where
 		threshold: Threshold,
 		batch_key: BatchKey,
 		async_index: u8,
-	) -> Result<GenericAsyncHandler<'a, ()>, DKGError> {
+	) -> Result<GenericAsyncHandler<'static, ()>, DKGError> {
 		let protocol = Box::pin(async move {
 			let ty = ProtocolType::Voting {
 				offline_stage: Arc::new(completed_offline_stage.clone()),

--- a/dkg-gadget/src/async_protocols/sign/state_machine.rs
+++ b/dkg-gadget/src/async_protocols/sign/state_machine.rs
@@ -84,7 +84,7 @@ impl StateMachineHandler for OfflineStage {
 		Ok(())
 	}
 
-	async fn on_finish<BI: BlockchainInterface>(
+	async fn on_finish<BI: BlockchainInterface + 'static>(
 		offline_stage: <Self as StateMachine>::Output,
 		params: AsyncProtocolParameters<BI>,
 		unsigned_proposal: Self::AdditionalReturnParam,

--- a/dkg-gadget/src/async_protocols/state_machine.rs
+++ b/dkg-gadget/src/async_protocols/state_machine.rs
@@ -47,7 +47,7 @@ where
 		local_ty: &ProtocolType,
 	) -> Result<(), <Self as StateMachine>::Err>;
 
-	async fn on_finish<BI: BlockchainInterface>(
+	async fn on_finish<BI: BlockchainInterface + 'static>(
 		result: <Self as StateMachine>::Output,
 		params: AsyncProtocolParameters<BI>,
 		additional_param: Self::AdditionalReturnParam,


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- in the `new_inner` method, instead of using `tokio::select!` macro, now we spawn each task into its own separate task.
- This would avoid the case where the protocol finishes and cancels the other tasks, instead we now give them a chance to complete.
- The way this work depends on the task type, for example in the outgoing task we process all the messages first and send it to the gossip engine, and later we check if the protocol is completed or terminated, if so, we stop.
- for the incoming protocol, we abort that task once we are completed the protocol (or the protocol error-ed)  in that case, we stop receiving any messages, since there is no point of that.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Hopefully, this resolves the DKG issue that we are facing right now :crossed_fingers:  
