### PR TITLE
No need to persist the session information starting back up

### DIFF
--- a/dkg-gadget/src/async_protocols/incoming.rs
+++ b/dkg-gadget/src/async_protocols/incoming.rs
@@ -92,8 +92,8 @@ impl TransformIncoming for Arc<SignedDKGMessage<Public>> {
 				}
 			},
 
-			(l, r) => {
-				log::warn!("Received message for mixed stage: Local: {:?}, payload: {:?}", l, r);
+			(_l, _r) => {
+				// log::warn!("Received message for mixed stage: Local: {:?}, payload: {:?}", l, r);
 				Ok(None)
 			},
 		}

--- a/dkg-gadget/src/persistence.rs
+++ b/dkg-gadget/src/persistence.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::async_protocols::remote::MetaHandlerStatus;
 use curv::elliptic::curves::Secp256k1;
 use dkg_primitives::{
 	serde_json,
@@ -23,60 +22,14 @@ use dkg_runtime_primitives::offchain::crypto::{Pair as AppPair, Public};
 use log::debug;
 use multi_party_ecdsa::protocols::multi_party_ecdsa::gg_2020::state_machine::keygen::LocalKey;
 use sc_keystore::LocalKeystore;
-use serde::{Deserialize, Serialize};
+
 use sp_core::Pair;
-use sp_runtime::traits::{AtLeast32BitUnsigned, Block, NumberFor};
 use std::{
 	fs,
 	io::{Error, ErrorKind},
 	path::PathBuf,
 	sync::Arc,
 };
-
-#[derive(Deserialize, Serialize, Clone, Debug)]
-pub struct StoredRoundsMetadata<C: AtLeast32BitUnsigned + Copy> {
-	pub session_id: SessionId,
-	pub status: MetaHandlerStatus,
-	pub started_at: C,
-}
-
-pub(crate) fn store_saved_rounds<B>(
-	session_id: SessionId,
-	started_at: NumberFor<B>,
-	status: MetaHandlerStatus,
-	base_path: Option<PathBuf>,
-) -> std::io::Result<()>
-where
-	B: Block,
-{
-	if let Some(path) = base_path {
-		let stored_rounds_metadata = StoredRoundsMetadata { session_id, started_at, status };
-		let serialized_data = serde_json::to_string(&stored_rounds_metadata)
-			.map_err(|_| Error::new(ErrorKind::Other, "Serialization failed"))?;
-		fs::write(path, &serialized_data[..])?;
-
-		Ok(())
-	} else {
-		Err(Error::new(ErrorKind::Other, "Base path not found, need to handle default path"))
-	}
-}
-
-pub(crate) fn load_saved_rounds<B>(
-	base_path: Option<PathBuf>,
-) -> std::io::Result<StoredRoundsMetadata<NumberFor<B>>>
-where
-	B: Block,
-{
-	if let Some(path) = base_path {
-		let serialized_data = fs::read(path)?;
-		let stored_rounds_metdata: StoredRoundsMetadata<NumberFor<B>> =
-			serde_json::from_slice(&serialized_data)
-				.map_err(|_| Error::new(ErrorKind::Other, "Deserialization failed"))?;
-		Ok(stored_rounds_metdata)
-	} else {
-		Err(Error::new(ErrorKind::Other, "Base path not found, need to handle default path"))
-	}
-}
 
 pub(crate) fn store_localkey(
 	key: LocalKey<Secp256k1>,

--- a/dkg-gadget/src/worker.rs
+++ b/dkg-gadget/src/worker.rs
@@ -352,19 +352,6 @@ where
 					log::warn!(target: "dkg_gadget::worker", "Overwriting rounds will result in termination of previous rounds!");
 				}
 				*lock = Some(status_handle);
-				// Store the saved rounds with Keygen status since we've executed the start handler
-				store_saved_rounds::<B>(
-					session_id,
-					now,
-					MetaHandlerStatus::Keygen,
-					self.base_path
-						.read()
-						.as_ref()
-						.map(|path| path.join(ACTIVE_ROUNDS_METADATA_FILE)),
-				)
-				.map_err(|e| DKGError::GenericError {
-					reason: format!("Failed to store saved rounds: {}", e),
-				})?;
 			},
 			ProtoStageType::Queued => {
 				debug!(target: "dkg_gadget::worker", "Starting queued protocol (obtaing the lock)");
@@ -374,19 +361,6 @@ where
 					log::warn!(target: "dkg_gadget::worker", "Overwriting rounds will result in termination of previous rounds!");
 				}
 				*lock = Some(status_handle);
-				// Store the saved rounds with Keygen status since we've executed the start handler
-				store_saved_rounds::<B>(
-					session_id,
-					now,
-					MetaHandlerStatus::Keygen,
-					self.base_path
-						.read()
-						.as_ref()
-						.map(|path| path.join(QUEUED_ROUNDS_METADATA_FILE)),
-				)
-				.map_err(|e| DKGError::GenericError {
-					reason: format!("Failed to store saved rounds: {}", e),
-				})?;
 			},
 			// When we are at signing stage, it is using the active rounds.
 			ProtoStageType::Signing => {
@@ -1520,35 +1494,6 @@ where
 			.collect())
 	}
 
-	// *** Main run loop ***
-	#[allow(dead_code)]
-	fn initialize_saved_rounds(&mut self) -> Result<(), DKGError> {
-		let active_rounds_metadata_path =
-			get_key_path(&self.base_path.read(), ACTIVE_ROUNDS_METADATA_FILE);
-		let queued_rounds_metadata_path =
-			get_key_path(&self.base_path.read(), QUEUED_ROUNDS_METADATA_FILE);
-
-		if let Ok(stored_active_rounds) = load_saved_rounds::<B>(active_rounds_metadata_path) {
-			let remote = AsyncProtocolRemote::new(
-				stored_active_rounds.started_at,
-				stored_active_rounds.session_id,
-			);
-			remote.set_status(stored_active_rounds.status);
-			*self.rounds.write() = Some(remote);
-		};
-
-		if let Ok(stored_queued_rounds) = load_saved_rounds::<B>(queued_rounds_metadata_path) {
-			let remote = AsyncProtocolRemote::new(
-				stored_queued_rounds.started_at,
-				stored_queued_rounds.session_id,
-			);
-			remote.set_status(stored_queued_rounds.status);
-			*self.next_rounds.write() = Some(remote);
-		};
-
-		Ok(())
-	}
-
 	/// Wait for initial finalized block
 	async fn initialization(&mut self) {
 		use futures::future;
@@ -1560,7 +1505,7 @@ where
 					*self.best_authorities.write() = self.get_best_authorities(&notif.header);
 					*self.current_validator_set.write() = active;
 					*self.queued_validator_set.write() = queued;
-					// Route this to the import notification handler
+					// Route this to the finality notification handler
 					self.handle_finality_notification(notif.clone());
 					log::debug!(target: "dkg_gadget::worker", "Initialization complete");
 					// End the initialization stream

--- a/dkg-gadget/src/worker.rs
+++ b/dkg-gadget/src/worker.rs
@@ -69,7 +69,7 @@ use dkg_runtime_primitives::{
 use crate::{
 	error, metric_set,
 	metrics::Metrics,
-	persistence::{load_saved_rounds, load_stored_key, store_saved_rounds},
+	persistence::load_stored_key,
 	utils::{find_authorities_change, get_key_path},
 	Client,
 };
@@ -77,16 +77,12 @@ use crate::{
 use crate::gossip_messages::public_key_gossip::handle_public_key_broadcast;
 use dkg_primitives::{
 	types::{DKGMessage, DKGMsgPayload, SignedDKGMessage},
-	utils::{
-		cleanup, ACTIVE_ROUNDS_METADATA_FILE, DKG_LOCAL_KEY_FILE, QUEUED_DKG_LOCAL_KEY_FILE,
-		QUEUED_ROUNDS_METADATA_FILE,
-	},
+	utils::{cleanup, DKG_LOCAL_KEY_FILE, QUEUED_DKG_LOCAL_KEY_FILE},
 };
 use dkg_runtime_primitives::{AuthoritySet, DKGApi};
 
 use crate::async_protocols::{
-	remote::{AsyncProtocolRemote, MetaHandlerStatus},
-	AsyncProtocolParameters, GenericAsyncHandler,
+	remote::AsyncProtocolRemote, AsyncProtocolParameters, GenericAsyncHandler,
 };
 
 pub const ENGINE_ID: sp_runtime::ConsensusEngineId = *b"WDKG";

--- a/standalone/node/src/chain_spec.rs
+++ b/standalone/node/src/chain_spec.rs
@@ -176,8 +176,8 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
 					authority_keys_from_seed("Alice", "Alice//stash"),
 					authority_keys_from_seed("Bob", "Bob//stash"),
 					authority_keys_from_seed("Charlie", "Charlie//stash"),
-					// authority_keys_from_seed("Dave", "Dave//stash"),
-					// authority_keys_from_seed("Eve", "Eve//stash"),
+					authority_keys_from_seed("Dave", "Dave//stash"),
+					authority_keys_from_seed("Eve", "Eve//stash"),
 				],
 				vec![],
 				// Sudo account
@@ -368,8 +368,8 @@ fn testnet_genesis(
 		grandpa: Default::default(),
 		dkg: DKGConfig {
 			authorities: initial_authorities.iter().map(|(.., x)| x.clone()).collect::<_>(),
-			keygen_threshold: 2,
-			signature_threshold: 1,
+			keygen_threshold: 5,
+			signature_threshold: 3,
 			authority_ids: initial_authorities.iter().map(|(x, ..)| x.clone()).collect::<_>(),
 		},
 		dkg_proposals: DKGProposalsConfig { initial_chain_ids, initial_r_ids, initial_proposers },


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Remove Unused methods and logic for Persisting the session information necessary for starting back up.
- During the testing, shutting down the node and starting it back up again works as normal, I guess that issues are got resolved with the recent updates and improvements we did to the DKG.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
- Closes #379 
- Closes #377 
