### PR TITLE
[PATCH] fix for DKG Rotation and Nonce

### DIFF
--- a/dkg-gadget/src/keystore.rs
+++ b/dkg-gadget/src/keystore.rs
@@ -19,7 +19,7 @@ use sp_application_crypto::{key_types::ACCOUNT, sr25519, CryptoTypePublicPair, R
 use sp_core::keccak_256;
 use sp_keystore::{SyncCryptoStore, SyncCryptoStorePtr};
 
-use log::warn;
+use log::trace;
 
 use dkg_runtime_primitives::{
 	crypto::{Public, Signature},
@@ -52,7 +52,7 @@ impl DKGKeystore {
 			.collect();
 
 		if public.len() > 1 {
-			warn!(target: "dkg", "🕸️  Multiple private keys found for: {:?} ({})", public, public.len());
+			trace!(target: "dkg", "🕸️  Multiple private keys found for: {:?} ({})", public, public.len());
 		}
 
 		public.get(0).cloned()
@@ -75,7 +75,7 @@ impl DKGKeystore {
 			.collect();
 
 		if public.len() > 1 {
-			warn!(target: "dkg", "🕸️  Multiple private keys found for: {:?} ({})", public, public.len());
+			trace!(target: "dkg", "🕸️  Multiple private keys found for: {:?} ({})", public, public.len());
 		}
 
 		public.get(0).cloned()

--- a/pallets/dkg-metadata/src/lib.rs
+++ b/pallets/dkg-metadata/src/lib.rs
@@ -812,7 +812,7 @@ pub mod pallet {
 				// Reset `RefreshInProgress` to false, so that we submit a new refresh.
 				RefreshInProgress::<T>::put(false);
 				frame_support::log::debug!(
-					target: "runtime::dkg",
+					target: "runtime::dkg_metadata",
 					"Next DKG Public Key: {}, Authority Set ID: {}",
 					hex::encode(key),
 					set_id,

--- a/pallets/dkg-metadata/src/lib.rs
+++ b/pallets/dkg-metadata/src/lib.rs
@@ -809,11 +809,14 @@ pub mod pallet {
 				// now increment the block number at which we expect next unsigned transaction.
 				let current_block = <frame_system::Pallet<T>>::block_number();
 				<NextUnsignedAt<T>>::put(current_block + T::UnsignedInterval::get());
-				// Trigger a refresh if we are submitting the next public key and we are ready to
-				// refresh
-				if Self::should_refresh(<frame_system::Pallet<T>>::block_number()) {
-					Self::do_refresh((set_id, key));
-				}
+				// Reset `RefreshInProgress` to false, so that we submit a new refresh.
+				RefreshInProgress::<T>::put(false);
+				frame_support::log::debug!(
+					target: "runtime::dkg",
+					"Next DKG Public Key: {}, Authority Set ID: {}",
+					hex::encode(key),
+					set_id,
+				);
 				Ok(().into())
 			} else {
 				Err(Error::<T>::InvalidPublicKeys.into())

--- a/pallets/dkg-proposal-handler/src/lib.rs
+++ b/pallets/dkg-proposal-handler/src/lib.rs
@@ -777,8 +777,7 @@ impl<T: Config> Pallet<T> {
 					}
 				},
 				Err(e) => {
-					// log the error
-					log::warn!(
+					log::trace!(
 						target: "runtime::dkg_proposal_handler",
 						"Failed to get next signed proposal: {}",
 						e


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Instead of doing the actual RefreshProposal inside the `submit_next_public_key` xt, and also inside the `on_initialize` hook, which could lead to double execution of the same proposal, instead we only now doing it in the `on_initialize` hook.
- However, we do reset the `RefreshInProgress` flag, whenever we get a new Public Key, so that the next call to `on_initialize` can call/execute the `do_refresh` call depending on the session progress.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 
