### PR TITLE
Fix Public Key Broadcast handler when `DKGWorker::rounds == None`

### DIFF
--- a/dkg-gadget/src/async_protocols/keygen/handler.rs
+++ b/dkg-gadget/src/async_protocols/keygen/handler.rs
@@ -108,7 +108,6 @@ where
 		let ty = match status {
 			DKGMsgStatus::ACTIVE => KeygenRound::ACTIVE,
 			DKGMsgStatus::QUEUED => KeygenRound::QUEUED,
-			DKGMsgStatus::UNKNOWN => KeygenRound::UNKNOWN,
 		};
 		let channel_type = ProtocolType::Keygen { ty, i, t, n };
 		new_inner(

--- a/dkg-gadget/src/gossip_messages/public_key_gossip.rs
+++ b/dkg-gadget/src/gossip_messages/public_key_gossip.rs
@@ -44,10 +44,6 @@ where
 	C: Client<B, BE> + 'static,
 	C::Api: DKGApi<B, AuthorityId, NumberFor<B>>,
 {
-	if dkg_worker.rounds.read().is_none() {
-		return Ok(())
-	}
-
 	// Get authority accounts
 	let header = &dkg_worker.latest_header.read().clone().ok_or(DKGError::NoHeader)?;
 	let current_block_number = *header.number();
@@ -100,6 +96,13 @@ where
 				session_id,
 				current_block_number,
 			)?;
+		} else {
+			log::debug!(
+				target: "dkg",
+				"SESSION {:?} | Need more signatures to submit next DKG public key, needs {} more",
+				msg.session_id,
+				threshold - aggregated_public_keys.keys_and_signatures.len()
+			);
 		}
 	}
 

--- a/dkg-primitives/src/types.rs
+++ b/dkg-primitives/src/types.rs
@@ -37,8 +37,6 @@ pub enum DKGMsgStatus {
 	ACTIVE,
 	/// Queued round,
 	QUEUED,
-	/// Unknown
-	UNKNOWN,
 }
 
 /// Gossip message struct for all DKG + Webb Protocol messages.


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Removes the need for the check for the `dkg_worker.rounds` inside the `handle_public_key_broadcast`
- Removes `DKGMsgStatus::UNKNOWN` and handle it in different way.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 
