### PR TITLE
move DkgKey subcommand to dkg-primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2282,6 +2282,7 @@ name = "dkg-primitives"
 version = "0.0.1"
 dependencies = [
  "chacha20poly1305",
+ "clap 3.2.23",
  "curv-kzen",
  "dkg-runtime-primitives",
  "fnv",
@@ -2294,6 +2295,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "rand 0.8.5",
  "round-based",
+ "sc-cli",
  "sc-keystore",
  "sc-service",
  "serde",

--- a/dkg-primitives/Cargo.toml
+++ b/dkg-primitives/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0", features = ["derive"] }
 rand = "0.8.4"
 chacha20poly1305 = "0.9.0"
 typed-builder = "0.9.1"
-
+clap = { version = "3.0", features = ["derive"] }
 curv = { package = "curv-kzen", version = "0.9", default-features = false }
 
 round-based = { version = "0.1.7", features = [] }
@@ -31,6 +31,9 @@ sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkad
 sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.30" }
 dkg-runtime-primitives = { path = "../dkg-runtime-primitives" }
 sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.30" }
+sc-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.30", features = [
+	"wasmtime",
+] }
 
 [dev-dependencies]
 sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.30" }

--- a/dkg-primitives/src/dkg_key_cli.rs
+++ b/dkg-primitives/src/dkg_key_cli.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use sc_cli::{Error, SubstrateCli};
 use sp_core::crypto::Pair;
 
-use dkg_primitives::utils::{decrypt_data, StoredLocalKey};
+use crate::utils::{decrypt_data, StoredLocalKey};
 
 /// Key utilities for the cli.
 #[derive(Debug, clap::Subcommand)]

--- a/dkg-primitives/src/lib.rs
+++ b/dkg-primitives/src/lib.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+pub mod dkg_key_cli;
 pub mod keys;
 pub mod types;
 pub mod utils;

--- a/parachain/node/src/cli.rs
+++ b/parachain/node/src/cli.rs
@@ -28,6 +28,10 @@ pub enum Subcommand {
 	/// Validate blocks.
 	CheckBlock(sc_cli::CheckBlockCmd),
 
+	/// DKG key management cli utilities
+	#[clap(subcommand)]
+	DKGKey(dkg_primitives::dkg_key_cli::DKGKeySubcommand),
+
 	/// Export blocks.
 	ExportBlocks(sc_cli::ExportBlocksCmd),
 

--- a/parachain/node/src/command.rs
+++ b/parachain/node/src/command.rs
@@ -230,6 +230,7 @@ pub fn run() -> Result<()> {
 			})
 		},
 		Some(Subcommand::Key(cmd)) => cmd.run(&cli),
+		Some(Subcommand::DKGKey(cmd)) => cmd.run(&cli),
 		Some(Subcommand::Benchmark(cmd)) => {
 			let runner = cli.create_runner(cmd)?;
 			// Switch on the concrete benchmark sub-command-

--- a/standalone/node/src/cli.rs
+++ b/standalone/node/src/cli.rs
@@ -32,7 +32,7 @@ pub enum Subcommand {
 
 	/// DKG key management cli utilities
 	#[clap(subcommand)]
-	DKGKey(crate::dkg_key::DKGKeySubcommand),
+	DKGKey(dkg_primitives::dkg_key_cli::DKGKeySubcommand),
 
 	/// Build a chain specification.
 	BuildSpec(sc_cli::BuildSpecCmd),

--- a/standalone/node/src/main.rs
+++ b/standalone/node/src/main.rs
@@ -21,7 +21,6 @@ mod service;
 mod benchmarking;
 mod cli;
 mod command;
-mod dkg_key;
 mod rpc;
 mod testnet_fixtures;
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Move DKGKey subcommand to dkg-primitives crate, this allows it to be imported to both parachain and standalone, and can also be used by upstream crates like tangle
- Refactor standalone and parachain crates

