### PR TITLE
Use the hash of the MP-ECDSA raw messages when possible

### DIFF
--- a/dkg-primitives/src/types.rs
+++ b/dkg-primitives/src/types.rs
@@ -69,7 +69,16 @@ impl<AuthorityId> SignedDKGMessage<AuthorityId> {
 	where
 		DKGMessage<AuthorityId>: Encode,
 	{
-		<<B::Header as Header>::Hashing as Hash>::hash_of(&self.msg.payload)
+		// in case of Keygen or Offline, we only need to hash the inner raw message bytes that
+		// are going to be sent to the state machine.
+		let bytes_to_hash = match self.msg.payload {
+			DKGMsgPayload::Keygen(m) => m.keygen_msg,
+			DKGMsgPayload::Offline(m) => m.offline_msg,
+			DKGMsgPayload::Vote(m) => m.encode(),
+			DKGMsgPayload::PublicKeyBroadcast(m) => m.encode(),
+			DKGMsgPayload::MisbehaviourBroadcast(m) => m.encode(),
+		};
+		<<B::Header as Header>::Hashing as Hash>::hash_of(&bytes_to_hash)
 	}
 }
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- in case of `Keygen` or `Offline` Messages, we only need to hash the inner raw message bytes that are going to be sent to the state machine.

