### PR TITLE
Expose session  in dkg-metadata as a runtime constant

### DIFF
--- a/pallets/dkg-metadata/src/lib.rs
+++ b/pallets/dkg-metadata/src/lib.rs
@@ -234,6 +234,10 @@ pub mod pallet {
 		#[pallet::constant]
 		type UnsignedPriority: Get<TransactionPriority>;
 
+		/// Session length helper allowing to query session length across runtime upgrades.
+		#[pallet::constant]
+		type SessionPeriod: Get<Self::BlockNumber>;
+
 		type WeightInfo: WeightInfo;
 	}
 

--- a/pallets/dkg-metadata/src/mock.rs
+++ b/pallets/dkg-metadata/src/mock.rs
@@ -139,6 +139,7 @@ impl pallet_dkg_metadata::Config for Test {
 	type UnsignedPriority = frame_support::traits::ConstU64<{ 1 << 20 }>;
 	type AuthorityIdOf = pallet_dkg_metadata::AuthorityIdOf<Self>;
 	type ProposalHandler = ();
+	type SessionPeriod = Period;
 	type WeightInfo = ();
 }
 

--- a/parachain/runtime/rococo/src/lib.rs
+++ b/parachain/runtime/rococo/src/lib.rs
@@ -513,6 +513,7 @@ impl pallet_dkg_metadata::Config for Runtime {
 	type Reputation = Reputation;
 	type AuthorityIdOf = pallet_dkg_metadata::AuthorityIdOf<Self>;
 	type ProposalHandler = DKGProposalHandler;
+	type SessionPeriod = Period;
 	type WeightInfo = pallet_dkg_metadata::weights::WebbWeight<Runtime>;
 }
 

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -625,6 +625,7 @@ impl pallet_dkg_metadata::Config for Runtime {
 	type Reputation = Reputation;
 	type AuthorityIdOf = pallet_dkg_metadata::AuthorityIdOf<Self>;
 	type ProposalHandler = DKGProposalHandler;
+	type SessionPeriod = Period;
 	type WeightInfo = pallet_dkg_metadata::weights::WebbWeight<Runtime>;
 }
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Expose session period as a runtime constant.
