### PR TITLE
Handle Critical and Non-Critical Errors in the Async Protocol 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5216,7 +5216,7 @@ dependencies = [
 [[package]]
 name = "multi-party-ecdsa"
 version = "0.8.2"
-source = "git+https://github.com/webb-tools/multi-party-ecdsa.git#574b863105e9c0bd796c866057764e0e55a49d54"
+source = "git+https://github.com/webb-tools/multi-party-ecdsa.git#dbfa21f13d4f75283a1cccd47213e49146a17d4d"
 dependencies = [
  "centipede",
  "curv-kzen",

--- a/pallets/dkg-proposal-handler/src/tests.rs
+++ b/pallets/dkg-proposal-handler/src/tests.rs
@@ -16,7 +16,6 @@ use crate::{mock::*, UnsignedProposalQueue};
 use codec::Encode;
 use frame_support::{
 	assert_err, assert_ok,
-	dispatch::DispatchClass,
 	traits::{Hooks, OnFinalize},
 	weights::constants::RocksDbWeight,
 };


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- previously, we handled all the async protocol errors are critical errors, but now we differentiate between critical and non critical errors.  



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Related to #494 
