### PR TITLE
fix duplicate field `description` key in Cargo.toml files

### DIFF
--- a/pallets/dkg-proposal-handler/rpc/runtime-api/Cargo.toml
+++ b/pallets/dkg-proposal-handler/rpc/runtime-api/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 license = "Apache-2.0"
 description = "RPC runtime API for DKG proposal handler which contains signed/pending DKG proposals"
 readme = "README.md"
-description = { workspace = true }
 publish = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true }

--- a/pallets/dkg-proposals/rpc/runtime-api/Cargo.toml
+++ b/pallets/dkg-proposals/rpc/runtime-api/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 license = "Apache-2.0"
 description = "RPC runtime API for DKG proposals"
 readme = "README.md"
-description = { workspace = true }
 authors = { workspace = true }
 publish = { workspace = true }
 homepage = { workspace = true }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Removes the duplicate of `description` key.
- Fixes the CI.

A side effect of #496 
