### PR TITLE
Use Node 18 for types CI steps

### DIFF
--- a/.github/workflows/publish-types.yml
+++ b/.github/workflows/publish-types.yml
@@ -21,7 +21,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
       - name: Install npm dependencies
         run: cd types && yarn install

--- a/.github/workflows/update-types.yml
+++ b/.github/workflows/update-types.yml
@@ -24,7 +24,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
       - name: Install npm dependencies
         run: cd types && yarn install

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webb-tools/dkg-substrate-types",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Polkadot.js type definitions required for interacting with Webb's DKG protocol",
   "main": "./build/index.js",
   "author": "Webb Developers <drew@webb.tools>",


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- With https://github.com/webb-tools/dkg-substrate/pull/561 Node 18 is required to build types, but CI was still on Node 16 and failing because of that. This change updates it to Node 18.
- [Here](https://github.com/webb-tools/dkg-substrate/actions/runs/4680147499/jobs/8291116271) you can see the error message


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Related to https://github.com/webb-tools/relayer/issues/456 
