### PR TITLE
First version of review

### DIFF
--- a/pallets/bridge-registry/src/weights.rs
+++ b/pallets/bridge-registry/src/weights.rs
@@ -50,6 +50,14 @@ pub trait WeightInfo {
 	fn force_reset_indices() -> Weight;
 }
 
+	/// <HB SBP Review M2
+	///
+	/// The code is running under the release 0.9.39 however the weights are still using weights v1
+	/// since it is considering only one value (ref time). The output of the CLI should configure the weights
+	/// to use the `from_parts(ref time,proof size)` fn
+	///
+	/// HB SBP Review M2>
+
 /// Weights for pallet_bridge_registry using the Substrate node and recommended hardware.
 pub struct WebbWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for WebbWeight<T> {

--- a/pallets/dkg-metadata/src/lib.rs
+++ b/pallets/dkg-metadata/src/lib.rs
@@ -1364,6 +1364,18 @@ pub mod pallet {
 		}
 	}
 
+	/// <HB SBP Review M2
+	///
+	/// Is the validate_unsigned fn used anywhere? I'm not able to find if this is used in any OCW.
+	///
+	/// We detected a vector atack with unsigned transactions from OCW: A malissuous validator might
+	/// push tempered data and the validators wouldn't be punished for this. Validators are only
+	/// subject to slashing if they create a block that violates the STF. Creating valid
+	/// transactions with tampered data would not result in slashing, and therefore the possibility
+	/// of malicious Validators in this context is real.
+	///
+	/// HB SBP Review M2>
+
 	#[pallet::validate_unsigned]
 	impl<T: Config> ValidateUnsigned for Pallet<T> {
 		type Call = Call<T>;
@@ -1454,6 +1466,15 @@ pub mod pallet {
 	}
 }
 
+/// <HB SBP Review M2
+///
+/// I would recommend extracting these functions into it's own file to help the pallet's readability
+/// and to reduce the number of lines to this file.
+///
+/// Here there is a proposal about a code organization for a big pallet like this one:
+/// https://github.com/paritytech/substrate/blob/master/frame/assets/src
+///
+/// HB SBP Review M2>
 impl<T: Config> Pallet<T> {
 	/// Return the current active DKG authority set.
 	pub fn authority_set() -> AuthoritySet<T::DKGId, T::MaxAuthorities> {

--- a/pallets/dkg-metadata/src/weights.rs
+++ b/pallets/dkg-metadata/src/weights.rs
@@ -55,6 +55,14 @@ pub trait WeightInfo {
 	fn force_unjail_keygen() -> Weight;
 }
 
+	/// <HB SBP Review M2
+	///
+	/// The code is running under the release 0.9.39 however the weights are still using weights v1
+	/// since it is considering only one value (ref time). The output of the CLI should configure the weights
+	/// to use the `from_parts(ref time,proof size)` fn
+	///
+	/// HB SBP Review M2>
+
 /// Weight functions for `pallet_dkg_metadata`.
 pub struct WebbWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for WebbWeight<T> {

--- a/pallets/dkg-proposal-handler/src/lib.rs
+++ b/pallets/dkg-proposal-handler/src/lib.rs
@@ -463,6 +463,17 @@ pub mod pallet {
 		}
 	}
 
+	/// <HB SBP Review M2
+	///
+	/// Is the validate_unsigned fn used anywhere? I'm not able to find if this is used in any OCW.
+	///
+	/// We detected a vector atack with unsigned transactions from OCW: A malissuous validator might
+	/// push tempered data and the validators wouldn't be punished for this. Validators are only
+	/// subject to slashing if they create a block that violates the STF. Creating valid
+	/// transactions with tampered data would not result in slashing, and therefore the possibility
+	/// of malicious Validators in this context is real.
+	///
+	/// HB SBP Review M2>
 	#[pallet::validate_unsigned]
 	impl<T: Config> ValidateUnsigned for Pallet<T> {
 		type Call = Call<T>;

--- a/pallets/dkg-proposal-handler/src/weights.rs
+++ b/pallets/dkg-proposal-handler/src/weights.rs
@@ -51,6 +51,15 @@ pub trait WeightInfo {
 	fn submit_signed_proposals(n: u32) -> Weight;
 	fn force_submit_unsigned_proposal() -> Weight;
 }
+
+	/// <HB SBP Review M2
+	///
+	/// The code is running under the release 0.9.39 however the weights are still using weights v1
+	/// since it is considering only one value (ref time). The output of the CLI should configure the weights
+	/// to use the `from_parts(ref time,proof size)` fn
+	///
+	/// HB SBP Review M2>
+
 /// Weight functions for `pallet_dkg_proposal_handler`.
 pub struct WebbWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config>WeightInfo for WebbWeight<T> {

--- a/pallets/dkg-proposals/src/weights.rs
+++ b/pallets/dkg-proposals/src/weights.rs
@@ -61,6 +61,14 @@ pub trait WeightInfo {
 	fn eval_vote_state(_c: u32,) -> Weight;
 }
 
+	/// <HB SBP Review M2
+	///
+	/// The code is running under the release 0.9.39 however the weights are still using weights v1
+	/// since it is considering only one value (ref time). The output of the CLI should configure the weights
+	/// to use the `from_parts(ref time,proof size)` fn
+	///
+	/// HB SBP Review M2>
+
 /// Weight functions for `pallet_dkg_proposals`.
 pub struct WebbWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for WebbWeight<T> {


### PR DESCRIPTION
# HB Substrate Builder Program - Milestone Review 2

## Documentation

The documentation is well-structured and covers the components of their solution in a clear way (**[https://docs.webb.tools/docs/](https://docs.webb.tools/docs/)**). However, my constructive feedback around the documentation is that bridging and privacy are one of the most complex topics in the industry, and the documentation lacks a more introductory part to help the end user understand the big picture of the product offering and its benefits. Some of these aspects are covered in the manifesto, but even with my developer (not privacy-oriented) profile, I struggled initially to understand the product offering. Therefore, I recommend starting the documentation with some basic examples or analogies to help users build their mental model of how the product works.

## Weights

The code base was upgraded to release 0.9.39, indicating that you are following the release pace consistently. However, you are still running weights v1 since the weights are still using the methods `from_ref_time` instead of the `from_parts` which involves the two fields from weights v2.

I recommend going through the following PR to migrate into Weights v2 properly:

https://github.com/paritytech/substrate/pull/11637

You might also consider creating a weights template like [this one](https://github.com/paritytech/substrate/blob/master/.maintain/frame-weight-template.hbs) to have more control over the weights process generation coming from the benchmarking.

## Pending SBP Milestone Review 1 Topics

In the previous SBP Milestone review, it was pointed out some issues/recommendations that have already been taken into account. However, I noticed that there are still many `unwrap`s that can lead to panics in the runtime, which should be avoided.

## DKG Metadata Pallet

This is a vague recommendation based on general good programming practices. I think that the DKG Metadata pallet is handling a diverse group of responsibilities, and the code readability might become hard to follow if it keeps growing. As a first step, I recommend moving the functions out of the main pallet file into its own file. Secondly, I would like to challenge if the pallet might be split into smaller pallets with more dedicated responsibilities, such as:

- DKG Key Pallet: Focusing on key management, this pallet would store the active and next DKG public keys, as well as the signatures for these keys.
- DKG Threshold and Refresh Pallet: This pallet would handle the DKG signature threshold and key refresh process.
- DKG Misbehavior and Reputation Pallet: This pallet would focus on managing misbehavior reporting and reputation tracking for DKG authorities.

I understand that this would involve a major refactor on a core functionality and might not be urgent or a blocker for deployment, but I just wanted to share this idea with the team.

## XCM

I agree that, at this point in time, trying to push the communication within chains using XCM might become a little bit cumbersome since, at the moment, XCM shines on transferring assets, not arbitrary data as needed in this project. For standalone chains that will have the intention to bridge to any parachain in Polkadot/Kusama, having the [xcm folder](https://github.com/paritytech/polkadot/tree/master/xcm/src) available in the code base of the project might be useful for creating the XCM set of messages so they can be bridged as data (Snowfork is doing something similar AFAIK).

## Offchain Workers

In the Delivery Services team we have detected some design assumptions & vulnerabilities that worths reading: https://forum.polkadot.network/t/offchain-workers-design-assumptions-vulnerabilities/2548
Going through the points described there might be useful for this project since it relays considerably on this functionality.