### PR TITLE
Remove all unwraps from runtime code

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -50,4 +50,4 @@ jobs:
         run: |
           sudo apt-get install protobuf-compiler &&
           cargo +nightly fmt --all -- --check &&
-          cargo clippy -Zunstable-options -- -D warnings
+          cargo clippy -Zunstable-options -- -D warnings -D clippy::unwrap_used

--- a/dkg-gadget/src/async_protocols/blockchain_interface.rs
+++ b/dkg-gadget/src/async_protocols/blockchain_interface.rs
@@ -123,7 +123,10 @@ impl<
 	fn send_result_to_test_client(&self, result: Result<(), String>) {
 		if let Some(bundle) = self.test_bundle.as_ref() {
 			if let Some(current_test_id) = *bundle.current_test_id.read() {
-				bundle.to_test_client.send((current_test_id, result)).unwrap();
+				let _ = bundle
+					.to_test_client
+					.send((current_test_id, result))
+					.map_err(|err| format!("send_result_to_test_client failed with error: {err}"));
 			}
 		}
 	}
@@ -230,7 +233,7 @@ where
 
 			if proposals_for_this_batch.len() == batch_key.len {
 				self.logger.info(format!("All proposals have resolved for batch {batch_key:?}"));
-				let proposals = lock.remove(&batch_key).unwrap(); // safe unwrap since lock is held
+				let proposals = lock.remove(&batch_key).expect("Cannot get lock on vote_resuls"); // safe unwrap since lock is held
 				std::mem::drop(lock);
 
 				if let Some(metrics) = self.metrics.as_ref() {

--- a/dkg-gadget/src/async_protocols/incoming.rs
+++ b/dkg-gadget/src/async_protocols/incoming.rs
@@ -99,7 +99,11 @@ impl TransformIncoming for Arc<SignedDKGMessage<Public>> {
 			(ProtocolType::Offline { .. }, DKGMsgPayload::Offline(..)) |
 			(ProtocolType::Voting { .. }, DKGMsgPayload::Vote(..)) => {
 				// only clone if the downstream receiver expects this type
-				let sender = self.msg.payload.async_proto_only_get_sender_id().unwrap();
+				let sender = self
+					.msg
+					.payload
+					.async_proto_only_get_sender_id()
+					.expect("Could not get sender id");
 				if sender != stream_type.get_i() {
 					if self.msg.session_id == this_session_id {
 						verify

--- a/dkg-gadget/src/async_protocols/mod.rs
+++ b/dkg-gadget/src/async_protocols/mod.rs
@@ -685,6 +685,7 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // allow unwraps in tests
 mod tests {
 	use dkg_primitives::crypto::AuthorityId;
 	use sp_application_crypto::ByteArray;

--- a/dkg-gadget/src/async_protocols/mod.rs
+++ b/dkg-gadget/src/async_protocols/mod.rs
@@ -581,7 +581,10 @@ where
 				}),
 				ProtocolType::Offline { unsigned_proposal, .. } =>
 					DKGMsgPayload::Offline(DKGOfflineMessage {
-						key: Vec::from(&unsigned_proposal.hash().unwrap() as &[u8]),
+						key: Vec::from(
+							&unsigned_proposal.hash().expect("Cannot hash unsigned proposal!")
+								as &[u8],
+						),
 						signer_set_id: party_id as u64,
 						offline_msg: serialized_body,
 						async_index,

--- a/dkg-gadget/src/async_protocols/sign/handler.rs
+++ b/dkg-gadget/src/async_protocols/sign/handler.rs
@@ -213,7 +213,9 @@ where
 				SignManual::new(message.clone(), completed_offline_stage)
 					.map_err(|err| Self::convert_mpc_sign_error_to_dkg_error_signing(err))?;
 
-			let partial_sig_bytes = serde_json::to_vec(&partial_signature).unwrap();
+			let partial_sig_bytes = serde_json::to_vec(&partial_signature).map_err(|_| {
+				DKGError::GenericError { reason: "Partial signature is invalid".to_string() }
+			})?;
 
 			let payload = DKGMsgPayload::Vote(DKGVoteMessage {
 				party_ind: *offline_i.as_ref(),

--- a/dkg-gadget/src/async_protocols/sign/state_machine.rs
+++ b/dkg-gadget/src/async_protocols/sign/state_machine.rs
@@ -71,7 +71,13 @@ impl<BI: BlockchainInterface + 'static> StateMachineHandler<BI> for OfflineStage
 					}
 				}
 
-				if local_ty.get_unsigned_proposal().unwrap().hash().unwrap() != msg.key.as_slice() {
+				if local_ty
+					.get_unsigned_proposal()
+					.expect("Unsigned proposal not found")
+					.hash()
+					.expect("Unsigned proposal hash failed") !=
+					msg.key.as_slice()
+				{
 					//dkg_logging::info!("Skipping passing of message to async proto since not
 					// correct unsigned proposal");
 					return Ok(())

--- a/dkg-gadget/src/async_protocols/test_utils.rs
+++ b/dkg-gadget/src/async_protocols/test_utils.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unwrap_used)] // allow unwraps in tests
 use crate::{
 	async_protocols::{blockchain_interface::BlockchainInterface, BatchKey},
 	proposal::make_signed_proposal,

--- a/dkg-gadget/src/async_protocols/test_utils.rs
+++ b/dkg-gadget/src/async_protocols/test_utils.rs
@@ -48,7 +48,10 @@ impl BlockchainInterface for TestDummyIface {
 	fn sign_and_send_msg(&self, unsigned_msg: DKGMessage<Public>) -> Result<(), DKGError> {
 		dkg_logging::info!(
 			"Sending message through iface id={}",
-			unsigned_msg.payload.async_proto_only_get_sender_id().unwrap()
+			unsigned_msg
+				.payload
+				.async_proto_only_get_sender_id()
+				.expect("Could not get sender id")
 		);
 		let faux_signed_message = SignedDKGMessage { msg: unsigned_msg, signature: None };
 		self.sender

--- a/dkg-gadget/src/debug_logger.rs
+++ b/dkg-gadget/src/debug_logger.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unwrap_used)]
 use dkg_logging::{debug, error, info, trace, warn};
 use std::{io::Write, sync::Arc};
 

--- a/dkg-gadget/src/gossip_messages/misbehaviour_report.rs
+++ b/dkg-gadget/src/gossip_messages/misbehaviour_report.rs
@@ -71,7 +71,10 @@ where
 		// Authenticate the message against the current authorities
 		let reporter = dkg_worker.authenticate_msg_origin(
 			is_main_round,
-			(authorities.clone().unwrap().0.into(), authorities.unwrap().1.into()),
+			(
+				authorities.clone().expect("Authorities not found!").0.into(),
+				authorities.expect("Authorities not found!").1.into(),
+			),
 			&signed_payload,
 			&msg.signature,
 		)?;

--- a/dkg-gadget/src/gossip_messages/public_key_gossip.rs
+++ b/dkg-gadget/src/gossip_messages/public_key_gossip.rs
@@ -66,7 +66,10 @@ where
 
 		dkg_worker.authenticate_msg_origin(
 			is_main_round,
-			(authorities.clone().unwrap().0.into(), authorities.unwrap().1.into()),
+			(
+				authorities.clone().expect("Authorities not found!").0.into(),
+				authorities.expect("Authorities not found!").1.into(),
+			),
 			&msg.pub_key,
 			&msg.signature,
 		)?;

--- a/dkg-gadget/src/keystore.rs
+++ b/dkg-gadget/src/keystore.rs
@@ -199,6 +199,7 @@ impl From<Option<SyncCryptoStorePtr>> for DKGKeystore {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // allow unwraps in tests
 mod tests {
 	use std::sync::Arc;
 

--- a/dkg-gadget/src/storage/misbehaviour_reports.rs
+++ b/dkg-gadget/src/storage/misbehaviour_reports.rs
@@ -56,7 +56,7 @@ where
 		return Err(DKGError::GenericError { reason: "No offchain storage available".to_string() })
 	}
 
-	let mut offchain = maybe_offchain.unwrap();
+	let mut offchain = maybe_offchain.expect("Should never happen, checked above");
 	offchain.set(STORAGE_PREFIX, AGGREGATED_MISBEHAVIOUR_REPORTS, &reports.clone().encode());
 	dkg_worker
 		.logger

--- a/dkg-gadget/src/storage/proposals.rs
+++ b/dkg-gadget/src/storage/proposals.rs
@@ -76,7 +76,7 @@ pub(crate) fn save_signed_proposals_in_storage<B, C, BE, MaxProposalLength, MaxA
 	}
 
 	let current_block_number = {
-		let header = latest_header.as_ref().unwrap();
+		let header = latest_header.as_ref().expect("Should not happen, checked above");
 		header.number()
 	};
 
@@ -87,7 +87,7 @@ pub(crate) fn save_signed_proposals_in_storage<B, C, BE, MaxProposalLength, MaxA
 			Some(ser_props) => OffchainSignedProposals::<NumberFor<B>, MaxProposalLength>::decode(
 				&mut &ser_props[..],
 			)
-			.unwrap(),
+			.expect("Unable to decode offchain signed proposal!"),
 			None => Default::default(),
 		};
 

--- a/dkg-gadget/src/storage/public_keys.rs
+++ b/dkg-gadget/src/storage/public_keys.rs
@@ -57,7 +57,7 @@ where
 	if maybe_offchain.is_none() {
 		return Err(DKGError::GenericError { reason: "No offchain storage available".to_string() })
 	}
-	let offchain = maybe_offchain.unwrap();
+	let offchain = maybe_offchain.expect("checked above");
 	let keys = aggregated_public_keys.get(&session_id).ok_or_else(|| DKGError::CriticalError {
 		reason: format!("Aggregated public key for session {session_id} does not exist in map"),
 	})?;

--- a/dkg-mock-blockchain/src/lib.rs
+++ b/dkg-mock-blockchain/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unwrap_used)] // allow unwraps in tests
 pub mod data_types;
 pub mod mock_blockchain_config;
 pub mod server;

--- a/dkg-primitives/src/keys.rs
+++ b/dkg-primitives/src/keys.rs
@@ -145,6 +145,7 @@ pub fn convert_to_eth_address(pub_key: &GE) -> Result<String, String> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
 	use super::{convert_to_checksum_eth_address, convert_to_eth_address, recover_pub_key_raw, GE};
 	use curv::{

--- a/dkg-primitives/src/keys.rs
+++ b/dkg-primitives/src/keys.rs
@@ -78,7 +78,7 @@ pub fn recover_pub_key_raw(message: &BigInt, v: u8, r: FE, s: FE) -> Result<GE, 
 	let g = GE::generator(); // G
 	let z = FE::from(message); // z
 
-	let rn = r.invert().unwrap(); // r^-1
+	let rn = r.invert().ok_or("Could not invert r value")?; // r^-1
 
 	let rsrn = r_calc * s * rn.clone(); // R * s * r^-1
 	let gzrn = g * z * rn; // G * z * r^-1

--- a/dkg-primitives/src/utils.rs
+++ b/dkg-primitives/src/utils.rs
@@ -145,6 +145,7 @@ pub fn select_random_set(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
 	use super::*;
 	use rand::RngCore;

--- a/dkg-runtime-primitives/src/lib.rs
+++ b/dkg-runtime-primitives/src/lib.rs
@@ -244,6 +244,7 @@ pub struct UnsignedProposal<MaxProposalLength: Get<u32> + Clone> {
 
 impl<MaxProposalLength: Get<u32> + Clone> UnsignedProposal<MaxProposalLength> {
 	#[cfg(feature = "testing")]
+	#[allow(clippy::unwrap_used)] // allow unwraps in tests
 	pub fn testing_dummy() -> Self {
 		let data = BoundedVec::try_from(vec![0, 1, 2]).unwrap();
 		Self {

--- a/dkg-test-orchestrator/src/main.rs
+++ b/dkg-test-orchestrator/src/main.rs
@@ -5,7 +5,7 @@
 //! In summary, running this test orchestrator is an "all in one" replacement
 //! for needing to run multiple clients. Each individual DKG node's stdout will be
 //! piped to the temporary directory
-
+#![allow(clippy::unwrap_used)] // allow unwraps in tests
 use crate::in_memory_gossip_engine::InMemoryGossipEngine;
 use dkg_gadget::worker::TestBundle;
 use dkg_mock_blockchain::*;

--- a/pallets/bridge-registry/src/lib.rs
+++ b/pallets/bridge-registry/src/lib.rs
@@ -183,6 +183,8 @@ pub mod pallet {
 		BridgeNotFound,
 		/// Too many resources.
 		TooManyResources,
+		/// Input out of bounds
+		OutOfBounds,
 	}
 
 	#[pallet::hooks]
@@ -290,7 +292,9 @@ impl<T: Config<I>, I: 'static> OnSignedProposal<DispatchError, T::MaxProposalLen
 					// Create the bridge record
 					let bridge_metadata = BridgeMetadata {
 						info: Default::default(),
-						resource_ids: vec![src_resource_id, dest_resource_id].try_into().unwrap(),
+						resource_ids: vec![src_resource_id, dest_resource_id]
+							.try_into()
+							.map_err(|_| Error::<T, I>::OutOfBounds)?,
 					};
 					Bridges::<T, I>::insert(next_bridge_index, bridge_metadata);
 					// Increment the next bridge index

--- a/pallets/bridge-registry/src/mock.rs
+++ b/pallets/bridge-registry/src/mock.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unwrap_used)]
 use super::*;
 use crate as pallet_bridge_registry;
 

--- a/pallets/bridge-registry/src/tests.rs
+++ b/pallets/bridge-registry/src/tests.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unwrap_used)]
 use super::*;
 use crate::mock::*;
 use frame_support::{assert_err, assert_ok, bounded_vec, BoundedVec};

--- a/pallets/dkg-metadata/src/mock.rs
+++ b/pallets/dkg-metadata/src/mock.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // construct_runtime requires this
-#![allow(clippy::from_over_into)]
+#![allow(clippy::from_over_into, clippy::unwrap_used)]
 use frame_support::{
 	construct_runtime, parameter_types, sp_io::TestExternalities, traits::GenesisBuild,
 	BasicExternalities,

--- a/pallets/dkg-metadata/src/tests.rs
+++ b/pallets/dkg-metadata/src/tests.rs
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+#![allow(clippy::unwrap_used)]
 use std::vec;
 
 use crate::mock::*;

--- a/pallets/dkg-proposal-handler/src/mock.rs
+++ b/pallets/dkg-proposal-handler/src/mock.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+#![allow(clippy::unwrap_used)]
 use crate as pallet_dkg_proposal_handler;
 use codec::{Decode, Encode};
 pub use dkg_runtime_primitives::{

--- a/pallets/dkg-proposal-handler/src/tests.rs
+++ b/pallets/dkg-proposal-handler/src/tests.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+#![allow(clippy::unwrap_used)]
 use crate as pallet_dkg_proposal_handler;
 use crate::{mock::*, UnsignedProposalQueue};
 use codec::Encode;

--- a/pallets/dkg-proposals/src/lib.rs
+++ b/pallets/dkg-proposals/src/lib.rs
@@ -410,7 +410,8 @@ pub mod pallet {
 				ChainNonces::<T>::insert(chain_id, ProposalNonce::from(0));
 			}
 			for (r_id, r_data) in self.initial_r_ids.iter() {
-				let bounded_input: BoundedVec<_, _> = r_data.clone().try_into().unwrap();
+				let bounded_input: BoundedVec<_, _> =
+					r_data.clone().try_into().expect("Genesis resources is too large");
 				Resources::<T>::insert(*r_id, bounded_input);
 			}
 
@@ -964,21 +965,24 @@ impl<T: Config>
 		{
 			ProposerCount::<T>::put(Self::proposer_count().saturating_add(1));
 			Proposers::<T>::insert(authority_account, true);
-			// TODO: Return result to avoid panic
+
 			let bounded_external_account: BoundedVec<_, _> =
-				external_account.clone().try_into().unwrap();
+				external_account.clone().try_into().expect("External account outside limits!");
 			ExternalProposerAccounts::<T>::insert(authority_account, bounded_external_account);
 		}
 		// Update the new authorities that are also proposers
-		// TODO: Return result to avoid panic
-		let bounded_authorities: BoundedVec<_, _> = authorities.try_into().unwrap();
+		let bounded_authorities: BoundedVec<_, _> = authorities
+			.try_into()
+			.expect("This should never happen, bounded authorities outside limits!");
 		AuthorityProposers::<T>::put(bounded_authorities.clone());
 		// Update the external accounts of the new authorities
-		// TODO: Return result to avoid panic
 		let mut bounded_new_external_accounts: BoundedVec<_, _> = Default::default();
 		for item in new_external_accounts {
-			let bounded_item: BoundedVec<_, _> = item.try_into().unwrap();
-			bounded_new_external_accounts.try_push(bounded_item).unwrap();
+			let bounded_item: BoundedVec<_, _> =
+				item.try_into().expect("New External account outside limits!");
+			bounded_new_external_accounts
+				.try_push(bounded_item)
+				.expect("New External account count outside limits!");
 		}
 		ExternalAuthorityProposerAccounts::<T>::put(bounded_new_external_accounts);
 		Self::deposit_event(Event::<T>::AuthorityProposersReset {

--- a/pallets/dkg-proposals/src/mock.rs
+++ b/pallets/dkg-proposals/src/mock.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+#![allow(clippy::unwrap_used)]
 #![cfg(test)]
 
 use super::*;

--- a/pallets/dkg-proposals/src/tests.rs
+++ b/pallets/dkg-proposals/src/tests.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 #![cfg(test)]
-
+#![allow(clippy::unwrap_used)]
 use super::{
 	mock::{
 		assert_events, new_test_ext, AccountId, Balances, ChainIdentifier, DKGProposals,

--- a/parachain/node/src/chain_spec/mod.rs
+++ b/parachain/node/src/chain_spec/mod.rs
@@ -93,7 +93,7 @@ fn generate_invulnerables<PK: Clone + Into<AccountId>>(
 		.iter()
 		.map(|pk| {
 			let account: AccountId = pk.0.clone().into();
-			let aura_id = AuraId::from_slice(account.as_ref()).unwrap();
+			let aura_id = AuraId::from_slice(account.as_ref()).expect("invalid aura id");
 			(account, aura_id, pk.clone().1)
 		})
 		.collect()

--- a/standalone/node/src/chain_spec.rs
+++ b/standalone/node/src/chain_spec.rs
@@ -368,7 +368,7 @@ fn testnet_genesis(
 				resource_ids: bounded_vec![RESOURCE_ID_HERMES_ATHENA, RESOURCE_ID_ATHENA_HERMES],
 				info: BridgeInfo {
 					additional: Default::default(),
-					display: SerdeData::from_str("hermes-athena").unwrap()
+					display: SerdeData::from_str("hermes-athena").expect("serialisation failed!")
 				}
 			}],
 			..Default::default()

--- a/standalone/node/src/testnet_fixtures.rs
+++ b/standalone/node/src/testnet_fixtures.rs
@@ -34,13 +34,13 @@ pub fn get_arana_bootnodes() -> Vec<MultiaddrWithPeerId> {
 	vec![
 		"/ip4/140.82.21.142/tcp/30333/p2p/12D3KooWPU2eWyZrDMVtNBiKYKLGPJw8EDjbkYeXMyotmdVBKNnx"
 			.parse()
-			.unwrap(),
+			.expect("Invalid bootnodes!"),
 		"/ip4/149.28.81.60/tcp/30333/p2p/12D3KooWHXiHVg1YX9PHsa8NrS5ZWEoaKBydqZvLoegw2bcTiCtf"
 			.parse()
-			.unwrap(),
+			.expect("Invalid bootnodes!"),
 		"/ip4/45.32.66.129/tcp/30333/p2p/12D3KooWPEpgPPBArgEa1v7X7YR5UiZ6BLxmCsNqC8F6fJ6cULLc"
 			.parse()
-			.unwrap(),
+			.expect("Invalid bootnodes!"),
 	]
 }
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Replace unwrap() with errors where possible
- In infallible functions, use expect() instead
- Add unwrap check to clippy CI
- Add allow unwrap to test files

**Reference issue to close (if applicable)**
Closes https://github.com/webb-tools/dkg-substrate/issues/572
