### PR TITLE
Cache on failure to speed up consequent builds per PR

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
+          # This will help speed up builds in a pipeline
+          cache-on-failure: "true"
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -78,6 +80,8 @@ jobs:
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
+          # This will help speed up builds in a pipeline
+          cache-on-failure: "true"
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
We normally have to wait at least half an hour for e2e tests and proposal tests just for the release binary to be built.

With this new addition, the first build per PR will still take the same amount of time as usual. However, if that first build fails, then, we will still cache the build artifacts, exponentially speeding up the next time we push to the PR branch. If there's any diff in the rust code, cargo will automatically rebuild the artifacts as needed, combining them into a single new binary per push.