### PR TITLE
Update mlc_config.json

### DIFF
--- a/.github/workflows/mlc_config.json
+++ b/.github/workflows/mlc_config.json
@@ -2,6 +2,9 @@
 	"ignorePatterns": [
 		{
 			"pattern": "^https://crates.io"
-		}
+		},
+		{
+			"pattern": "^https://twitter.com"
+		},
 	]
 }


### PR DESCRIPTION
Twitter.com's link sometimes is not reachable by the pipeline. We should skip checking it since we know it's a legit link anyways.
