### PR TITLE
Add shared key for CI Rust cache to speedup builds

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v1.3.0
+        with:
+          shared-key: "rust"
 
       - name: Run Linters
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,7 @@ env:
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: git
 
 jobs:
-  # code coverage job; moved to own workflow file due to running out of disk space. 
+  # code coverage job; moved to own workflow file due to running out of disk space.
   # The runner will stop working when the machine runs out of disk space. Free space left: 72 MB
   coverage:
     name: coverage
@@ -40,13 +40,15 @@ jobs:
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v1.3.0
+        with:
+          shared-key: "rust"
 
       - name: Install Tarpaulin
         run: cargo install cargo-tarpaulin
 
       - name: Run Tarpaulin
         run : cargo tarpaulin --out Xml -p pallet-dkg-metadata -p pallet-dkg-proposal-handler -p pallet-dkg-proposals -p dkg-primitives -p dkg-runtime-primitives --locked --jobs 16 --timeout 3600 --skip-clean -- --test-threads 16
-        
+
       - name: Upload CodeCov
         uses: codecov/codecov-action@v2
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           # This will help speed up builds in a pipeline
           cache-on-failure: "true"
+          shared-key: "rust"
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -84,6 +85,7 @@ jobs:
         with:
           # This will help speed up builds in a pipeline
           cache-on-failure: "true"
+          shared-key: "rust"
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
I noticed in the Slack chat that this repo also has problems with slow CI time. While solving the same problem in relayer I noticed that adding this shared-key for rust-cache helps a lot to speed up builds. So lets see if it helps here too.

**Summary of changes**
Changes introduced in this pull request:
- Set shared-key for rust-cache CI action



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 
