### PR TITLE
Enable incremental builds for release in workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,7 +31,7 @@ jobs:
           echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
 
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.2
+        uses: mozilla-actions/sccache-action@master
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -95,7 +95,7 @@ jobs:
           echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
 
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.2
+        uses: mozilla-actions/sccache-action@master
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Build Standalone Node for E2E Tests (Release)
         env:
           CARGO_INCREMENTAL: 1
-        run: cargo build --frozen --release -p dkg-standalone-node --features integration-tests
+        run: cargo build --release -p dkg-standalone-node --features integration-tests
 
       - name: Run E2E Tests
         run: cd dkg-test-suite && yarn test:e2e
@@ -138,7 +138,7 @@ jobs:
       - name: Build Standalone Node for Integration Tests (Release)
         env:
           CARGO_INCREMENTAL: 1
-        run: cargo build --frozen --release -p dkg-standalone-node
+        run: cargo build --release -p dkg-standalone-node
 
       - name: Run Proposals E2E Tests
         run: cd dkg-test-suite && yarn test:proposals

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,12 +33,11 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3
 
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2.3.0
+      - name: cache
+        uses: actions/cache@v3
         with:
-          # This will help speed up builds in a pipeline
-          cache-on-failure: "true"
-          cache-all-crates: "true"
+          path: [ '~/.cargo/registry', 'target/release', 'target/debug' ]
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -78,6 +77,12 @@ jobs:
       - name: Run E2E Tests
         run: cd dkg-test-suite && yarn test:e2e
 
+      - name: cache
+        uses: actions/cache@v3
+        with:
+          path: [ '~/.cargo/registry', 'target/release', 'target/debug' ]
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+
   integration-tests:
     name: integration-tests
     runs-on: ubuntu-latest
@@ -98,12 +103,11 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3
 
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2.3.0
+      - name: cache
+        uses: actions/cache@v3
         with:
-          # This will help speed up builds in a pipeline
-          cache-on-failure: "true"
-          cache-all-crates: "true"
+          path: [ '~/.cargo/registry', 'target/release', 'target/debug' ]
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -142,3 +146,10 @@ jobs:
 
       - name: Run Proposals E2E Tests
         run: cd dkg-test-suite && yarn test:proposals
+
+      - name: cache
+        if: always()
+        uses: actions/cache@v3
+        with:
+          path: ['~/.cargo/registry', 'target/release', 'target/debug']
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,7 +31,7 @@ jobs:
           echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
 
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@master
+        uses: mozilla-actions/sccache-action@v0.0.3
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -95,7 +95,7 @@ jobs:
           echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
 
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@master
+        uses: mozilla-actions/sccache-action@v0.0.3
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -62,6 +62,8 @@ jobs:
         run: dvc pull
 
       - name: Build Standalone Node for E2E Tests (Release)
+        env:
+          CARGO_INCREMENTAL: 1
         run: cargo build --release -p dkg-standalone-node --features integration-tests
 
       - name: Run E2E Tests
@@ -116,6 +118,8 @@ jobs:
         run: dvc pull
 
       - name: Build Standalone Node for Integration Tests (Release)
+        env:
+          CARGO_INCREMENTAL: 1
         run: cargo build --release -p dkg-standalone-node
 
       - name: Run Proposals E2E Tests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,10 +34,11 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.3
 
       - name: cache
+        if: always()
         uses: actions/cache@v3
         with:
-          path: [ '~/.cargo/registry', 'target/release', 'target/debug' ]
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+          path: '~/.cargo/registry,target/release,target/debug'
+          key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -78,10 +79,11 @@ jobs:
         run: cd dkg-test-suite && yarn test:e2e
 
       - name: cache
+        if: always()
         uses: actions/cache@v3
         with:
-          path: [ '~/.cargo/registry', 'target/release', 'target/debug' ]
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+          path: '~/.cargo/registry,target/release,target/debug'
+          key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}
 
   integration-tests:
     name: integration-tests
@@ -104,10 +106,11 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.3
 
       - name: cache
+        if: always()
         uses: actions/cache@v3
         with:
-          path: [ '~/.cargo/registry', 'target/release', 'target/debug' ]
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+          path: '~/.cargo/registry,target/release,target/debug'
+          key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -151,5 +154,5 @@ jobs:
         if: always()
         uses: actions/cache@v3
         with:
-          path: ['~/.cargo/registry', 'target/release', 'target/debug']
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+          path: '~/.cargo/registry,target/release,target/debug'
+          key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,9 +35,12 @@ jobs:
 
       - name: cache
         if: always()
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
-          path: '~/.cargo/registry,target/release,target/debug'
+          path: |
+            ~/.cargo/registry
+            target/release
+            target/debug
           key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}
 
       - name: Install toolchain
@@ -80,9 +83,12 @@ jobs:
 
       - name: cache
         if: always()
-        uses: actions/cache@v3
+        uses: actions/cache/save@v3
         with:
-          path: '~/.cargo/registry,target/release,target/debug'
+          path: |
+            ~/.cargo/registry
+            target/release
+            target/debug
           key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}
 
   integration-tests:
@@ -107,9 +113,12 @@ jobs:
 
       - name: cache
         if: always()
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
-          path: '~/.cargo/registry,target/release,target/debug'
+          path: |
+            ~/.cargo/registry
+            target/release
+            target/debug
           key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}
 
       - name: Install toolchain
@@ -152,7 +161,10 @@ jobs:
 
       - name: cache
         if: always()
-        uses: actions/cache@v3
+        uses: actions/cache/save@v3
         with:
-          path: '~/.cargo/registry,target/release,target/debug'
+          path: |
+            ~/.cargo/registry
+            target/release
+            target/debug
           key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,7 +41,7 @@ jobs:
             ~/.cargo/registry
             target/release
             target/debug
-          key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}
+          key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}-e2e
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -89,7 +89,7 @@ jobs:
             ~/.cargo/registry
             target/release
             target/debug
-          key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}
+          key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}-e2e
 
   integration-tests:
     name: integration-tests
@@ -119,7 +119,7 @@ jobs:
             ~/.cargo/registry
             target/release
             target/debug
-          key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}
+          key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}-integration-tests
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -167,4 +167,4 @@ jobs:
             ~/.cargo/registry
             target/release
             target/debug
-          key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}
+          key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}-integration-tests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Build Standalone Node for E2E Tests (Release)
         env:
           CARGO_INCREMENTAL: 1
-        run: cargo build --locked --release -p dkg-standalone-node --features integration-tests
+        run: cargo build --frozen --release -p dkg-standalone-node --features integration-tests
 
       - name: Run E2E Tests
         run: cd dkg-test-suite && yarn test:e2e
@@ -138,7 +138,7 @@ jobs:
       - name: Build Standalone Node for Integration Tests (Release)
         env:
           CARGO_INCREMENTAL: 1
-        run: cargo build --locked --release -p dkg-standalone-node
+        run: cargo build --frozen --release -p dkg-standalone-node
 
       - name: Run Proposals E2E Tests
         run: cd dkg-test-suite && yarn test:proposals

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3
 
-      - name: cache
+      - name: Restore Cache
         if: always()
         uses: actions/cache/restore@v3
         with:
@@ -81,7 +81,7 @@ jobs:
       - name: Run E2E Tests
         run: cd dkg-test-suite && yarn test:e2e
 
-      - name: cache
+      - name: Save Cache
         if: always()
         uses: actions/cache/save@v3
         with:
@@ -111,7 +111,7 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3
 
-      - name: cache
+      - name: Restore Cache
         if: always()
         uses: actions/cache/restore@v3
         with:
@@ -159,7 +159,7 @@ jobs:
       - name: Run Proposals E2E Tests
         run: cd dkg-test-suite && yarn test:proposals
 
-      - name: cache
+      - name: Save Cache
         if: always()
         uses: actions/cache/save@v3
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,6 +25,14 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
+      - name: Configure sccache
+        run: |
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          echo “SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.2
+
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -80,6 +88,14 @@ jobs:
 
       - name: Checkout Code
         uses: actions/checkout@v3
+
+      - name: Configure sccache
+        run: |
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          echo “SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.2
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           # This will help speed up builds in a pipeline
           cache-on-failure: "true"
+          cache-all-crates: "true"
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -72,7 +73,7 @@ jobs:
       - name: Build Standalone Node for E2E Tests (Release)
         env:
           CARGO_INCREMENTAL: 1
-        run: cargo build --release -p dkg-standalone-node --features integration-tests
+        run: cargo build --locked --release -p dkg-standalone-node --features integration-tests
 
       - name: Run E2E Tests
         run: cd dkg-test-suite && yarn test:e2e
@@ -102,6 +103,7 @@ jobs:
         with:
           # This will help speed up builds in a pipeline
           cache-on-failure: "true"
+          cache-all-crates: "true"
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -136,7 +138,7 @@ jobs:
       - name: Build Standalone Node for Integration Tests (Release)
         env:
           CARGO_INCREMENTAL: 1
-        run: cargo build --release -p dkg-standalone-node
+        run: cargo build --locked --release -p dkg-standalone-node
 
       - name: Run Proposals E2E Tests
         run: cd dkg-test-suite && yarn test:proposals

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,7 +34,7 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.3
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@v2.3.0
         with:
           # This will help speed up builds in a pipeline
           cache-on-failure: "true"
@@ -99,7 +99,7 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.3
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@v2.3.0
         with:
           # This will help speed up builds in a pipeline
           cache-on-failure: "true"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Configure sccache
         run: |
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-          echo “SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
 
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.2
@@ -92,7 +92,7 @@ jobs:
       - name: Configure sccache
         run: |
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-          echo “SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
 
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,16 @@ jobs:
       - name: Checkout Sources
         uses: actions/checkout@v2
 
+      - name: Restore Cache
+        if: always()
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            target/release
+            target/debug
+          key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}-tests
+
       - name: Install Toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -51,4 +61,16 @@ jobs:
         run: sudo apt-get install protobuf-compiler
 
       - name: Run tests
+        env:
+          CARGO_INCREMENTAL: 1
         run: cargo nextest run
+
+      - name: Save Cache
+        if: always()
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            target/release
+            target/debug
+          key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}-tests

--- a/dkg-gadget/src/async_protocols/sign/handler.rs
+++ b/dkg-gadget/src/async_protocols/sign/handler.rs
@@ -274,7 +274,7 @@ where
 
 			params
 				.logger
-				.error_signing(format!("RD0 on {offline_i} for {hash_of_proposal:?}"));
+				.info_signing(format!("RD0 on {offline_i} for {hash_of_proposal:?}"));
 
 			if sigs.len() != number_of_partial_sigs {
 				params.logger.error_signing(format!(

--- a/standalone/node/Cargo.toml
+++ b/standalone/node/Cargo.toml
@@ -74,7 +74,7 @@ substrate-build-script-utils = { workspace = true }
 
 [features]
 default = []
-runtime-benchmarks = ["dkg-standalone-runtime/runtime-benchmarks",	
+runtime-benchmarks = ["dkg-standalone-runtime/runtime-benchmarks",
                       "frame-benchmarking/runtime-benchmarks",
 	                "frame-benchmarking-cli/runtime-benchmarks",]
 integration-tests = ["dkg-standalone-runtime/integration-tests"]


### PR DESCRIPTION
Incremental compilation is disabled by default for release builds. So, instead of using debug builds as was tried in #607 , we will instead keep release builds and set an env var to override incremental compilation.

To test this PR, we will first need the pipeline to finish once. Then, we will need to re-trigger (e.g., with an empty commit) the pipeline, and expect to see the rebuild time significantly shorter.