### PR TITLE
Experiment with docker caching in pipeline

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -82,7 +82,7 @@ jobs:
         run: cd dkg-test-suite && yarn test:e2e
 
       - name: Save Cache
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/cache/save@v3
         with:
           path: |
@@ -160,7 +160,7 @@ jobs:
         run: cd dkg-test-suite && yarn test:proposals
 
       - name: Save Cache
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/cache/save@v3
         with:
           path: |

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -9,44 +9,57 @@ on:
     tags:
       - v*
   pull_request:
-    branches: [ master ]
 
 env:
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: git
 
 jobs:
-  push:
+  build:
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
         with:
-          access_token: ${{ github.token }}
-      - uses: actions/checkout@v2
-      - name: Build Image
-        run: ./scripts/build-standalone-docker.sh
-      - name: Log into registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Push image
-        run: |
-          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/dkg-standalone-node
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-          # Change all uppercase to lowercase
-          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+      - name: Get package version
+        id: get_version
+        run: echo ::set-output name=VERSION::$(grep "^version" ./standalone/node/Cargo.toml | egrep -o "([0-9\.]+)")
 
-          # Strip git ref prefix from version
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+      - name: Restore Cache
+        if: always()
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            /tmp/.buildx-cache
+          key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}-images
 
-          # Strip "v" prefix from tag name
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          dockerfile: ./docker/Standalone.Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/dkg-standalone-node:${{ steps.get_version.outputs.VERSION }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=inline
 
-          # Use Docker `edge` tag convention
-          [ "$VERSION" == "master" ] && VERSION=edge
-
-          echo IMAGE_ID=$IMAGE_ID
-          echo VERSION=$VERSION
-          docker tag webb-tools/dkg-standalone-node $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:$VERSION
+      - name: Save Cache
+        if: always()
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            /tmp/.buildx-cache
+          key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}-images

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -23,9 +23,6 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
@@ -37,13 +34,10 @@ jobs:
         id: get_version
         run: echo ::set-output name=VERSION::$(grep "^version" ./standalone/node/Cargo.toml | egrep -o "([0-9\.]+)")
 
-      - name: Restore Cache
-        if: always()
-        uses: actions/cache/restore@v3
+      - name: Cache Docker images.
+        uses: ScribeMD/docker-cache@0.3.3
         with:
-          path: |
-            /tmp/.buildx-cache
-          key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}-docker-image
+          key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}-images-docker
 
       - name: Build and push
         id: docker_build
@@ -53,13 +47,3 @@ jobs:
           file: ./docker/Standalone.Dockerfile
           push: true
           tags: ghcr.io/${{ github.repository_owner }}/dkg-standalone-node:${{ steps.get_version.outputs.VERSION }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
-
-      - name: Save Cache
-        if: ${{ !cancelled() }}
-        uses: actions/cache/save@v3
-        with:
-          path: |
-            /tmp/.buildx-cache
-          key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}-docker-image

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: |
-            /tmp/.buildx-cache
+            /tmp/buildkit-mount*/.buildx-cache
           key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}-images
 
       - name: Build and push
@@ -53,7 +53,7 @@ jobs:
           dockerfile: ./docker/Standalone.Dockerfile
           push: true
           tags: ghcr.io/${{ github.repository_owner }}/dkg-standalone-node:${{ steps.get_version.outputs.VERSION }}
-          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-from: type=local,src=/tmp/buildkit-mount*/.buildx-cache
           cache-to: type=inline
 
       - name: Save Cache
@@ -61,5 +61,5 @@ jobs:
         uses: actions/cache/save@v3
         with:
           path: |
-            /tmp/.buildx-cache
+            /tmp/buildkit-mount*/.buildx-cache
           key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}-images

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           path: |
             /tmp/.buildx-cache
-          key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}-images
+          key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}-docker
 
       - name: Build and push
         id: docker_build
@@ -62,4 +62,4 @@ jobs:
         with:
           path: |
             /tmp/.buildx-cache
-          key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}-images
+          key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}-docker

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: |
-            /tmp/buildkit-mount*/.buildx-cache
+            /tmp/.buildx-cache
           key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}-images
 
       - name: Build and push
@@ -53,13 +53,13 @@ jobs:
           file: ./docker/Standalone.Dockerfile
           push: true
           tags: ghcr.io/${{ github.repository_owner }}/dkg-standalone-node:${{ steps.get_version.outputs.VERSION }}
-          cache-from: type=local,src=/tmp/buildkit-mount*/.buildx-cache
-          cache-to: type=inline
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
 
       - name: Save Cache
         if: always()
         uses: actions/cache/save@v3
         with:
           path: |
-            /tmp/buildkit-mount*/.buildx-cache
+            /tmp/.buildx-cache
           key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}-images

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -50,7 +50,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./
-          dockerfile: ./docker/Standalone.Dockerfile
+          file: ./docker/Standalone.Dockerfile
           push: true
           tags: ghcr.io/${{ github.repository_owner }}/dkg-standalone-node:${{ steps.get_version.outputs.VERSION }}
           cache-from: type=local,src=/tmp/buildkit-mount*/.buildx-cache

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           path: |
             /tmp/.buildx-cache
-          key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}-docker
+          key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}-docker-image
 
       - name: Build and push
         id: docker_build
@@ -57,9 +57,9 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 
       - name: Save Cache
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/cache/save@v3
         with:
           path: |
             /tmp/.buildx-cache
-          key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}-docker
+          key: ${{ runner.os }}-cargo-index-${{ github.ref_name }}-docker-image

--- a/docker/Standalone.Dockerfile
+++ b/docker/Standalone.Dockerfile
@@ -25,10 +25,10 @@ RUN apt-get update && apt-get install -y git cmake clang curl libssl-dev llvm li
 COPY --from=planner /dkg/recipe.json recipe.json
 COPY rust-toolchain.toml .
 # Build dependencies - this is the caching Docker layer!
-RUN cargo chef cook -Z sparse-registry --release --recipe-path recipe.json 
+RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
 # Build application
-RUN cargo build -Z sparse-registry --release -p dkg-standalone-node
+RUN cargo build --release -p dkg-standalone-node
 
 # This is the 2nd stage: a very small image where we copy the DKG binary."
 


### PR DESCRIPTION
Building and pushing the docker image is the longest-running job. We might be able to cut down on pipeline times further by caching the docker builds per branch.
