### PR TITLE
Experiment with mac runners for e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ jobs:
   # dkg-substrate integration tests
   e2e:
     name: e2e-tests
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.1
@@ -93,7 +93,7 @@ jobs:
 
   integration-tests:
     name: integration-tests
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -62,7 +62,7 @@ jobs:
         run: dvc pull
 
       - name: Install Protobuf
-        run: sudo apt-get install protobuf-compiler
+        run: brew install protobuf
 
       - name: Install Packages
         run: cd dkg-test-suite && yarn install --frozen-lockfile
@@ -140,7 +140,7 @@ jobs:
         run: dvc pull
 
       - name: Install Protobuf
-        run: sudo apt-get install protobuf-compiler
+        run: brew install protobuf
 
       - name: Install Packages
         run: cd dkg-test-suite && yarn install --frozen-lockfile


### PR DESCRIPTION
Mac runners are free (for open-source projects), and, offer higher capabilities compared to the Linux runners we currently use (which means better performance). This may help make e2e tests more reliable in the pipeline, since flakiness is an issue for e2e tests.

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
