### PR TITLE
Proposer selection upgrade and proposer set voting protocol in fallback case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1887,6 +1887,7 @@ dependencies = [
 name = "dkg-runtime-primitives"
 version = "0.0.1"
 dependencies = [
+ "ethabi",
  "ethereum",
  "ethereum-types",
  "frame-support",
@@ -2253,6 +2254,17 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "ethabi"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7413c5f74cc903ea37386a8965a936cbeb334bd270862fdece542c1b2dcbc898"
+dependencies = [
+ "ethereum-types",
+ "hex",
+ "sha3 0.10.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ dkg-mock-blockchain = { path = "dkg-mock-blockchain", default-features = false }
 dkg-test-orchestrator = { path = "dkg-test-orchestrator", default-features = false }
 
 futures = "0.3.15"
+ethabi = { version = "18.0.0", default-features = false }
 clap = { version = "4.0.32", features = ["derive"] }
 rand = "0.8.4"
 hex-literal = { package = "hex-literal", version = "0.3.3" }

--- a/dkg-gadget/src/async_protocols/blockchain_interface.rs
+++ b/dkg-gadget/src/async_protocols/blockchain_interface.rs
@@ -25,13 +25,12 @@ use crate::{
 use codec::Encode;
 use curv::{elliptic::curves::Secp256k1, BigInt};
 use dkg_primitives::{
-	types::{
-		DKGError, DKGMessage, DKGPublicKeyMessage, DKGSignedPayload, SessionId, SignedDKGMessage,
-	},
+	types::{DKGError, DKGMessage, SessionId, SignedDKGMessage},
 	utils::convert_signature,
 };
 use dkg_runtime_primitives::{
 	crypto::{AuthorityId, Public},
+	gossip_messages::{DKGSignedPayload, PublicKeyMessage},
 	AggregatedPublicKeys, AuthoritySet, MaxAuthorities, MaxProposalLength, UnsignedProposal,
 };
 use multi_party_ecdsa::protocols::multi_party_ecdsa::gg_2020::{
@@ -72,7 +71,7 @@ pub trait BlockchainInterface: Send + Sync {
 		batch_key: BatchKey,
 		message: BigInt,
 	) -> Result<(), DKGError>;
-	fn gossip_public_key(&self, key: DKGPublicKeyMessage) -> Result<(), DKGError>;
+	fn gossip_public_key(&self, key: PublicKeyMessage) -> Result<(), DKGError>;
 	fn store_public_key(
 		&self,
 		key: LocalKey<Secp256k1>,
@@ -261,7 +260,7 @@ where
 		Ok(())
 	}
 
-	fn gossip_public_key(&self, key: DKGPublicKeyMessage) -> Result<(), DKGError> {
+	fn gossip_public_key(&self, key: PublicKeyMessage) -> Result<(), DKGError> {
 		gossip_public_key::<B, C, BE, GE>(
 			&self.keystore,
 			self.gossip_engine.clone(),

--- a/dkg-gadget/src/async_protocols/incoming.rs
+++ b/dkg-gadget/src/async_protocols/incoming.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use dkg_primitives::types::{DKGError, DKGMessage, DKGMsgPayload, SessionId, SignedDKGMessage};
+use dkg_primitives::types::{DKGError, DKGMessage, NetworkMsgPayload, SessionId, SignedDKGMessage};
 use dkg_runtime_primitives::{crypto::Public, MaxAuthorities};
 use futures::Stream;
 use round_based::Msg;
@@ -95,9 +95,9 @@ impl TransformIncoming for Arc<SignedDKGMessage<Public>> {
 		Self: Sized,
 	{
 		match (stream_type, &self.msg.payload) {
-			(ProtocolType::Keygen { .. }, DKGMsgPayload::Keygen(..)) |
-			(ProtocolType::Offline { .. }, DKGMsgPayload::Offline(..)) |
-			(ProtocolType::Voting { .. }, DKGMsgPayload::Vote(..)) => {
+			(ProtocolType::Keygen { .. }, NetworkMsgPayload::Keygen(..)) |
+			(ProtocolType::Offline { .. }, NetworkMsgPayload::Offline(..)) |
+			(ProtocolType::Voting { .. }, NetworkMsgPayload::Vote(..)) => {
 				// only clone if the downstream receiver expects this type
 				let sender = self
 					.msg

--- a/dkg-gadget/src/async_protocols/keygen/state_machine.rs
+++ b/dkg-gadget/src/async_protocols/keygen/state_machine.rs
@@ -20,8 +20,8 @@ use crate::{
 	debug_logger::DebugLogger,
 };
 use async_trait::async_trait;
-use dkg_primitives::types::{DKGError, DKGMessage, DKGMsgPayload, DKGPublicKeyMessage};
-use dkg_runtime_primitives::{crypto::Public, MaxAuthorities};
+use dkg_primitives::types::{DKGError, DKGMessage, NetworkMsgPayload};
+use dkg_runtime_primitives::{crypto::Public, gossip_messages::PublicKeyMessage, MaxAuthorities};
 use futures::channel::mpsc::UnboundedSender;
 use multi_party_ecdsa::protocols::multi_party_ecdsa::gg_2020::state_machine::keygen::{
 	Keygen, ProtocolMessage,
@@ -42,7 +42,7 @@ impl<BI: BlockchainInterface + 'static> StateMachineHandler<BI> for Keygen {
 		let DKGMessage { payload, session_id, .. } = msg.body;
 		// Send the payload to the appropriate AsyncProtocols
 		match payload {
-			DKGMsgPayload::Keygen(msg) => {
+			NetworkMsgPayload::Keygen(msg) => {
 				logger.info_keygen(format!(
 					"Handling Keygen inbound message from id={}, session={}",
 					msg.sender_id, session_id
@@ -87,7 +87,7 @@ impl<BI: BlockchainInterface + 'static> StateMachineHandler<BI> for Keygen {
 		// public_key_gossip.rs:gossip_public_key [2] store public key locally (public_keys.rs:
 		// store_aggregated_public_keys)
 		let session_id = params.session_id;
-		let pub_key_msg = DKGPublicKeyMessage {
+		let pub_key_msg = PublicKeyMessage {
 			session_id,
 			pub_key: local_key.public_key().to_bytes(true).to_vec(),
 			signature: vec![],

--- a/dkg-gadget/src/async_protocols/mod.rs
+++ b/dkg-gadget/src/async_protocols/mod.rs
@@ -26,13 +26,13 @@ pub mod test_utils;
 use curv::elliptic::curves::Secp256k1;
 use dkg_primitives::{
 	crypto::Public,
-	types::{
-		DKGError, DKGKeygenMessage, DKGMessage, DKGMsgPayload, DKGMsgStatus, DKGOfflineMessage,
-		SessionId,
-	},
+	types::{DKGError, DKGMessage, DKGMsgStatus, NetworkMsgPayload, SessionId},
 	AuthoritySet,
 };
-use dkg_runtime_primitives::{MaxAuthorities, UnsignedProposal};
+use dkg_runtime_primitives::{
+	gossip_messages::{DKGKeygenMessage, DKGOfflineMessage},
+	MaxAuthorities, UnsignedProposal,
+};
 use futures::{
 	channel::mpsc::{UnboundedReceiver, UnboundedSender},
 	Future, StreamExt,
@@ -575,12 +575,12 @@ where
 				None => None,
 			};
 			let payload = match &proto_ty {
-				ProtocolType::Keygen { .. } => DKGMsgPayload::Keygen(DKGKeygenMessage {
+				ProtocolType::Keygen { .. } => NetworkMsgPayload::Keygen(DKGKeygenMessage {
 					sender_id: party_id,
 					keygen_msg: serialized_body,
 				}),
 				ProtocolType::Offline { unsigned_proposal, .. } =>
-					DKGMsgPayload::Offline(DKGOfflineMessage {
+					NetworkMsgPayload::Offline(DKGOfflineMessage {
 						key: Vec::from(
 							&unsigned_proposal.hash().expect("Cannot hash unsigned proposal!")
 								as &[u8],

--- a/dkg-gadget/src/async_protocols/sign/handler.rs
+++ b/dkg-gadget/src/async_protocols/sign/handler.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use curv::{arithmetic::Converter, elliptic::curves::Secp256k1, BigInt};
-use dkg_runtime_primitives::UnsignedProposal;
+use dkg_runtime_primitives::{gossip_messages::DKGVoteMessage, UnsignedProposal};
 use futures::{stream::FuturesUnordered, StreamExt, TryStreamExt};
 use multi_party_ecdsa::protocols::multi_party_ecdsa::gg_2020::state_machine::{
 	keygen::LocalKey,
@@ -29,7 +29,7 @@ use crate::async_protocols::{
 	BatchKey, GenericAsyncHandler, KeygenPartyId, OfflinePartyId, ProtocolType, Threshold,
 };
 use dkg_primitives::types::{
-	DKGError, DKGMessage, DKGMsgPayload, DKGMsgStatus, DKGVoteMessage, SignedDKGMessage,
+	DKGError, DKGMessage, DKGMsgStatus, NetworkMsgPayload, SignedDKGMessage,
 };
 use dkg_runtime_primitives::{crypto::Public, MaxAuthorities};
 use futures::FutureExt;
@@ -217,7 +217,7 @@ where
 				DKGError::GenericError { reason: "Partial signature is invalid".to_string() }
 			})?;
 
-			let payload = DKGMsgPayload::Vote(DKGVoteMessage {
+			let payload = NetworkMsgPayload::Vote(DKGVoteMessage {
 				party_ind: *offline_i.as_ref(),
 				// use the hash of proposal as "round key" ONLY for purposes of ensuring
 				// uniqueness We only want voting to happen amongst voters under the SAME
@@ -249,7 +249,7 @@ where
 			));
 
 			while let Some(msg) = incoming_wrapper.next().await {
-				if let DKGMsgPayload::Vote(dkg_vote_msg) = msg.body.payload {
+				if let NetworkMsgPayload::Vote(dkg_vote_msg) = msg.body.payload {
 					// only process messages which are from the respective proposal
 					if dkg_vote_msg.round_key.as_slice() == hash_of_proposal {
 						params.logger.info_signing("Found matching round key!".to_string());

--- a/dkg-gadget/src/async_protocols/sign/state_machine.rs
+++ b/dkg-gadget/src/async_protocols/sign/state_machine.rs
@@ -20,7 +20,7 @@ use crate::{
 	debug_logger::DebugLogger,
 };
 use async_trait::async_trait;
-use dkg_primitives::types::{DKGError, DKGMessage, DKGMsgPayload, SignedDKGMessage};
+use dkg_primitives::types::{DKGError, DKGMessage, NetworkMsgPayload, SignedDKGMessage};
 use dkg_runtime_primitives::{crypto::Public, MaxAuthorities, UnsignedProposal};
 use futures::channel::mpsc::UnboundedSender;
 use multi_party_ecdsa::protocols::multi_party_ecdsa::gg_2020::state_machine::sign::{
@@ -52,7 +52,7 @@ impl<BI: BlockchainInterface + 'static> StateMachineHandler<BI> for OfflineStage
 
 		// Send the payload to the appropriate AsyncProtocols
 		match payload {
-			DKGMsgPayload::Offline(msg) => {
+			NetworkMsgPayload::Offline(msg) => {
 				let message: Msg<OfflineProtocolMessage> =
 					match serde_json::from_slice(msg.offline_msg.as_slice()) {
 						Ok(msg) => msg,

--- a/dkg-gadget/src/async_protocols/test_utils.rs
+++ b/dkg-gadget/src/async_protocols/test_utils.rs
@@ -6,12 +6,14 @@ use crate::{
 use codec::Encode;
 use curv::{elliptic::curves::Secp256k1, BigInt};
 use dkg_primitives::{
-	types::{
-		DKGError, DKGMessage, DKGPublicKeyMessage, DKGSignedPayload, SessionId, SignedDKGMessage,
-	},
+	types::{DKGError, DKGMessage, SessionId, SignedDKGMessage},
 	utils::convert_signature,
 };
-use dkg_runtime_primitives::{crypto::Public, MaxProposalLength, UnsignedProposal};
+use dkg_runtime_primitives::{
+	crypto::Public,
+	gossip_messages::{DKGSignedPayload, PublicKeyMessage},
+	MaxProposalLength, UnsignedProposal,
+};
 use multi_party_ecdsa::protocols::multi_party_ecdsa::gg_2020::{
 	party_i::SignatureRecid, state_machine::keygen::LocalKey,
 };
@@ -87,7 +89,7 @@ impl BlockchainInterface for TestDummyIface {
 		Ok(())
 	}
 
-	fn gossip_public_key(&self, _key: DKGPublicKeyMessage) -> Result<(), DKGError> {
+	fn gossip_public_key(&self, _key: PublicKeyMessage) -> Result<(), DKGError> {
 		// we do not gossip the public key in the test interface
 		Ok(())
 	}

--- a/dkg-gadget/src/gossip_messages/mod.rs
+++ b/dkg-gadget/src/gossip_messages/mod.rs
@@ -14,4 +14,5 @@
 //
 pub mod dkg_message;
 pub mod misbehaviour_report;
+pub mod proposer_vote_gossip;
 pub mod public_key_gossip;

--- a/dkg-gadget/src/gossip_messages/proposer_vote_gossip.rs
+++ b/dkg-gadget/src/gossip_messages/proposer_vote_gossip.rs
@@ -1,0 +1,209 @@
+use crate::{gossip_engine::GossipEngineIface, worker::AggregatedProposerVotesStore};
+// Copyright 2022 Webb Technologies Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Handles non-dkg messages
+use crate::{
+	storage::proposer_votes::store_aggregated_proposer_votes,
+	worker::{DKGWorker, KeystoreExt},
+	Client,
+};
+use codec::Encode;
+use dkg_primitives::types::{
+	DKGError, DKGMessage, DKGMsgStatus, NetworkMsgPayload, SignedDKGMessage,
+};
+use dkg_runtime_primitives::{
+	crypto::{AuthorityId, Public},
+	ethereum_abi::IntoAbiToken,
+	gossip_messages::{ProposerVoteMessage, PublicKeyMessage},
+	AggregatedProposerVotes, DKGApi, MaxAuthorities, MaxProposalLength, MaxSignatureLength,
+	MaxVoteLength, MaxVotes,
+};
+use sc_client_api::Backend;
+use sp_runtime::{
+	traits::{Block, Get, Header, NumberFor},
+	BoundedVec,
+};
+
+pub(crate) fn handle_proposer_vote<B, BE, C, GE>(
+	dkg_worker: &DKGWorker<B, BE, C, GE>,
+	dkg_msg: DKGMessage<Public>,
+) -> Result<(), DKGError>
+where
+	B: Block,
+	BE: Backend<B> + 'static,
+	GE: GossipEngineIface + 'static,
+	C: Client<B, BE> + 'static,
+	C::Api: DKGApi<B, AuthorityId, NumberFor<B>, MaxProposalLength, MaxAuthorities>,
+{
+	// Get authority accounts
+	let header = &dkg_worker.latest_header.read().clone().ok_or(DKGError::NoHeader)?;
+	let current_block_number = *header.number();
+	let authorities = dkg_worker.validator_set(header).map(|a| (a.0.authorities, a.1.authorities));
+	if authorities.is_none() {
+		return Err(DKGError::NoAuthorityAccounts)
+	}
+
+	if let NetworkMsgPayload::ProposerVote(msg) = dkg_msg.payload {
+		dkg_worker
+			.logger
+			.debug(format!("SESSION {} | Received proposer vote broadcast", msg.session_id));
+
+		let is_main_round = {
+			if let Some(round) = dkg_worker.rounds.read().as_ref() {
+				msg.session_id == round.session_id
+			} else {
+				false
+			}
+		};
+
+		// Create encoded message
+		let mut encoded_vote_msg =
+			msg.encode_abi().try_into().map_err(|_| DKGError::InputOutOfBounds)?;
+
+		let session_id = msg.session_id;
+		let mut lock = dkg_worker.aggregated_proposer_votes.write();
+		let votes = lock.entry((msg.session_id, msg.new_governor)).or_insert_with(|| {
+			AggregatedProposerVotes {
+				session_id: msg.session_id,
+				encoded_vote: encoded_vote_msg,
+				voters: Default::default(),
+				signatures: Default::default(),
+			}
+		});
+		// Fetch the current threshold for the DKG. We will use the
+		// current threshold to determine if we have enough signatures
+		// to submit the next DKG public key.
+		let threshold = dkg_worker.get_next_signature_threshold(header) as usize;
+		dkg_worker.logger.debug(format!(
+			"SESSION {} | Threshold {} | Aggregated proposer votes {}",
+			msg.session_id,
+			threshold,
+			votes.voters.len()
+		));
+
+		if votes.voters.len() > threshold {
+			store_aggregated_proposer_votes(&dkg_worker, votes)?;
+		} else {
+			dkg_worker.logger.debug(format!(
+				"SESSION {} | Need more signatures to submit next DKG public key, needs {} more",
+				msg.session_id,
+				(threshold + 1) - votes.voters.len()
+			));
+		}
+	}
+
+	Ok(())
+}
+
+pub(crate) fn gossip_proposer_vote<B, C, BE, GE>(
+	dkg_worker: &DKGWorker<B, BE, C, GE>,
+	msg: ProposerVoteMessage,
+) -> Result<(), DKGError>
+where
+	B: Block,
+	BE: Backend<B>,
+	GE: GossipEngineIface,
+	C: Client<B, BE>,
+	MaxProposalLength: Get<u32> + Clone + Send + Sync + 'static + std::fmt::Debug,
+	MaxAuthorities: Get<u32> + Clone + Send + Sync + 'static + std::fmt::Debug,
+	C::Api: DKGApi<
+		B,
+		AuthorityId,
+		<<B as Block>::Header as Header>::Number,
+		MaxProposalLength,
+		MaxAuthorities,
+	>,
+{
+	let public = dkg_worker.key_store.get_authority_public_key();
+	let encoded_vote: BoundedVec<u8, MaxVoteLength> =
+		msg.encode_abi().try_into().map_err(|_| DKGError::InputOutOfBounds)?;
+
+	if let Ok(signature) = dkg_worker.key_store.sign(&public, &encoded_vote) {
+		let encoded_signature = signature.encode();
+		let payload = NetworkMsgPayload::ProposerVote(ProposerVoteMessage {
+			signature: encoded_signature.clone(),
+			..msg.clone()
+		});
+
+		let status =
+			if msg.session_id == 0u64 { DKGMsgStatus::ACTIVE } else { DKGMsgStatus::QUEUED };
+		let message = DKGMessage::<AuthorityId> {
+			sender_id: public.clone(),
+			// we need to gossip the final public key to all parties, so no specific recipient in
+			// this case.
+			recipient_id: None,
+			status,
+			session_id: msg.session_id,
+			payload,
+		};
+		let encoded_dkg_message = message.encode();
+
+		crate::utils::inspect_outbound("proposer_vote", encoded_dkg_message.len());
+
+		match dkg_worker.key_store.sign(&public, &encoded_dkg_message) {
+			Ok(sig) => {
+				let signed_dkg_message =
+					SignedDKGMessage { msg: message, signature: Some(sig.encode()) };
+				if let Err(e) = dkg_worker.keygen_gossip_engine.gossip(signed_dkg_message) {
+					dkg_worker
+						.keygen_gossip_engine
+						.logger()
+						.error(format!("Failed to gossip DKG public key: {e:?}"));
+				}
+			},
+			Err(e) => dkg_worker.logger.error(format!("🕸️  Error signing DKG message: {e:?}")),
+		}
+
+		let mut lock = dkg_worker.aggregated_proposer_votes.write();
+		let bounded_voters: BoundedVec<Public, MaxAuthorities> =
+			vec![public.clone()].try_into().map_err(|_| DKGError::InputOutOfBounds)?;
+		let bounded_encoded_sig: BoundedVec<u8, MaxSignatureLength> =
+			encoded_signature.clone().try_into().map_err(|_| DKGError::InputOutOfBounds)?;
+		let bounded_sigs: BoundedVec<BoundedVec<u8, MaxSignatureLength>, MaxAuthorities> =
+			vec![bounded_encoded_sig.clone()]
+				.try_into()
+				.map_err(|_| DKGError::InputOutOfBounds)?;
+		let votes = lock.entry((msg.session_id, encoded_vote.to_vec())).or_insert_with(|| {
+			AggregatedProposerVotes {
+				session_id: msg.session_id,
+				encoded_vote,
+				voters: bounded_voters,
+				signatures: bounded_sigs,
+			}
+		});
+
+		if votes.voters.contains(&public) {
+			return Ok(())
+		}
+
+		votes.voters.try_push(public).map_err(|_| DKGError::InputOutOfBounds)?;
+		votes
+			.signatures
+			.try_push(encoded_signature.try_into().map_err(|_| DKGError::InputOutOfBounds)?)
+			.map_err(|_| DKGError::InputOutOfBounds)?;
+
+		dkg_worker
+			.keygen_gossip_engine
+			.logger()
+			.debug(format!("Gossiping local node proposer vote for {:?} ", msg));
+		Ok(())
+	} else {
+		dkg_worker
+			.keygen_gossip_engine
+			.logger()
+			.error("Could not sign proposer vote".to_string());
+		Err(DKGError::CannotSign)
+	}
+}

--- a/dkg-gadget/src/gossip_messages/public_key_gossip.rs
+++ b/dkg-gadget/src/gossip_messages/public_key_gossip.rs
@@ -21,11 +21,11 @@ use crate::{
 };
 use codec::Encode;
 use dkg_primitives::types::{
-	DKGError, DKGMessage, DKGMsgPayload, DKGMsgStatus, DKGPublicKeyMessage, SessionId,
-	SignedDKGMessage,
+	DKGError, DKGMessage, DKGMsgStatus, NetworkMsgPayload, SessionId, SignedDKGMessage,
 };
 use dkg_runtime_primitives::{
 	crypto::{AuthorityId, Public},
+	gossip_messages::PublicKeyMessage,
 	AggregatedPublicKeys, DKGApi, MaxAuthorities, MaxProposalLength,
 };
 use sc_client_api::Backend;
@@ -51,7 +51,7 @@ where
 		return Err(DKGError::NoAuthorityAccounts)
 	}
 
-	if let DKGMsgPayload::PublicKeyBroadcast(msg) = dkg_msg.payload {
+	if let NetworkMsgPayload::PublicKeyBroadcast(msg) = dkg_msg.payload {
 		dkg_worker
 			.logger
 			.debug(format!("SESSION {} | Received public key broadcast", msg.session_id));
@@ -118,7 +118,7 @@ pub(crate) fn gossip_public_key<B, C, BE, GE>(
 	key_store: &DKGKeystore,
 	gossip_engine: Arc<GE>,
 	aggregated_public_keys: &mut HashMap<SessionId, AggregatedPublicKeys>,
-	msg: DKGPublicKeyMessage,
+	msg: PublicKeyMessage,
 ) where
 	B: Block,
 	BE: Backend<B>,
@@ -138,7 +138,7 @@ pub(crate) fn gossip_public_key<B, C, BE, GE>(
 
 	if let Ok(signature) = key_store.sign(&public, &msg.pub_key) {
 		let encoded_signature = signature.encode();
-		let payload = DKGMsgPayload::PublicKeyBroadcast(DKGPublicKeyMessage {
+		let payload = NetworkMsgPayload::PublicKeyBroadcast(PublicKeyMessage {
 			signature: encoded_signature.clone(),
 			..msg.clone()
 		});

--- a/dkg-gadget/src/proposal.rs
+++ b/dkg-gadget/src/proposal.rs
@@ -15,10 +15,10 @@ use std::sync::Arc;
 //
 use crate::{debug_logger::DebugLogger, Client};
 use codec::Encode;
-use dkg_primitives::types::{DKGError, DKGSignedPayload};
+use dkg_primitives::types::DKGError;
 use dkg_runtime_primitives::{
-	crypto::AuthorityId, offchain::storage_keys::OFFCHAIN_PUBLIC_KEY_SIG, DKGApi, DKGPayloadKey,
-	RefreshProposalSigned,
+	crypto::AuthorityId, gossip_messages::DKGSignedPayload,
+	offchain::storage_keys::OFFCHAIN_PUBLIC_KEY_SIG, DKGApi, DKGPayloadKey, RefreshProposalSigned,
 };
 use sc_client_api::Backend;
 use sp_api::offchain::STORAGE_PREFIX;

--- a/dkg-gadget/src/storage/mod.rs
+++ b/dkg-gadget/src/storage/mod.rs
@@ -16,4 +16,5 @@
 // limitations under the License.
 pub mod misbehaviour_reports;
 pub mod proposals;
+pub mod proposer_votes;
 pub mod public_keys;

--- a/dkg-gadget/src/storage/proposer_votes.rs
+++ b/dkg-gadget/src/storage/proposer_votes.rs
@@ -1,0 +1,67 @@
+// This file is part of Webb.
+
+// Copyright (C) 2021 Webb Technologies Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use crate::{gossip_engine::GossipEngineIface, worker::DKGWorker, Client};
+use codec::Encode;
+use dkg_primitives::types::DKGError;
+use dkg_runtime_primitives::{
+	crypto::AuthorityId, offchain::storage_keys::AGGREGATED_PROPOSER_VOTES,
+	AggregatedMisbehaviourReports, AggregatedProposerVotes, DKGApi,
+};
+use sc_client_api::Backend;
+use sp_application_crypto::sp_core::offchain::{OffchainStorage, STORAGE_PREFIX};
+use sp_runtime::traits::{Block, Get, NumberFor};
+
+/// stores aggregated proposer votes offchain
+pub(crate) fn store_aggregated_proposer_votes<
+	B,
+	BE,
+	C,
+	GE,
+	MaxProposalLength,
+	MaxSignatureLength,
+	MaxAuthorities,
+	MaxVoteLength,
+>(
+	dkg_worker: &DKGWorker<B, BE, C, GE>,
+	votes: &AggregatedProposerVotes<AuthorityId, MaxSignatureLength, MaxAuthorities, MaxVoteLength>,
+) -> Result<(), DKGError>
+where
+	B: Block,
+	GE: GossipEngineIface + 'static,
+	BE: Backend<B>,
+	C: Client<B, BE>,
+	MaxProposalLength: Get<u32> + Clone + Send + Sync + 'static + std::fmt::Debug,
+	MaxSignatureLength:
+		Get<u32> + Clone + Send + Sync + 'static + scale_info::TypeInfo + std::fmt::Debug,
+	MaxVoteLength:
+		Get<u32> + Clone + Send + Sync + 'static + scale_info::TypeInfo + std::fmt::Debug,
+	MaxAuthorities:
+		Get<u32> + Clone + Send + Sync + 'static + scale_info::TypeInfo + std::fmt::Debug,
+	C::Api: DKGApi<B, AuthorityId, NumberFor<B>, MaxProposalLength, MaxAuthorities>,
+{
+	let maybe_offchain = dkg_worker.backend.offchain_storage();
+	if maybe_offchain.is_none() {
+		return Err(DKGError::GenericError { reason: "No offchain storage available".to_string() })
+	}
+
+	let mut offchain = maybe_offchain.expect("Should never happen, checked above");
+	offchain.set(STORAGE_PREFIX, AGGREGATED_PROPOSER_VOTES, &votes.clone().encode());
+	dkg_worker
+		.logger
+		.trace(format!("Stored aggregated proposer votes {:?}", votes.encode()));
+	Ok(())
+}

--- a/dkg-gadget/src/storage/public_keys.rs
+++ b/dkg-gadget/src/storage/public_keys.rs
@@ -62,7 +62,6 @@ where
 		reason: format!("Aggregated public key for session {session_id} does not exist in map"),
 	})?;
 	if is_genesis_round {
-		//dkg_worker.dkg_state.listening_for_active_pub_key = false;
 		perform_storing_of_aggregated_public_keys::<B, BE>(
 			offchain,
 			keys,
@@ -72,7 +71,6 @@ where
 			logger,
 		);
 	} else {
-		//dkg_worker.dkg_state.listening_for_pub_key = false;
 		perform_storing_of_aggregated_public_keys::<B, BE>(
 			offchain,
 			keys,

--- a/dkg-primitives/src/lib.rs
+++ b/dkg-primitives/src/lib.rs
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
+
 pub mod dkg_key_cli;
 pub mod keys;
 pub mod types;

--- a/dkg-runtime-primitives/Cargo.toml
+++ b/dkg-runtime-primitives/Cargo.toml
@@ -10,6 +10,7 @@ repository = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+ethabi = { workspace = true }
 impl-trait-for-tuples = { version = "0.2.2", default-features = false }
 codec = { package = "parity-scale-codec", version = "3", default-features = false, features = [
 	"derive",

--- a/dkg-runtime-primitives/src/ethereum_abi.rs
+++ b/dkg-runtime-primitives/src/ethereum_abi.rs
@@ -1,0 +1,33 @@
+use codec::Encode;
+use ethabi::{encode, Token};
+use sp_std::{vec, vec::Vec};
+
+use crate::gossip_messages::ProposerVoteMessage;
+
+#[allow(clippy::wrong_self_convention)]
+pub trait IntoAbiToken {
+	fn into_abi(&self) -> Token;
+	fn encode_abi(&self) -> Vec<u8> {
+		let token = self.into_abi();
+
+		encode(&[token])
+	}
+}
+
+impl IntoAbiToken for [u8; 32] {
+	fn into_abi(&self) -> Token {
+		Token::Bytes(self.to_vec())
+	}
+}
+
+impl IntoAbiToken for ProposerVoteMessage {
+	fn into_abi(&self) -> Token {
+		let tokens = vec![
+			Token::Bytes(self.proposer_leaf_index.encode()),
+			Token::Bytes(self.new_governor.encode()),
+		];
+		let merkle_path_tokens =
+			self.proposer_merkle_path.iter().map(|x| x.into_abi()).collect::<Vec<Token>>();
+		Token::Tuple([tokens, merkle_path_tokens].concat())
+	}
+}

--- a/dkg-runtime-primitives/src/gossip_messages.rs
+++ b/dkg-runtime-primitives/src/gossip_messages.rs
@@ -1,0 +1,91 @@
+use crate::{crypto::AuthorityId, MisbehaviourType, SessionId, SignerSetId};
+use codec::{Decode, Encode};
+use sp_std::vec::Vec;
+
+#[derive(Debug, Clone, Decode, Encode)]
+#[cfg_attr(feature = "scale-info", derive(scale_info::TypeInfo))]
+pub struct DKGKeygenMessage {
+	/// Sender id / party index
+	pub sender_id: u16,
+	/// Serialized keygen msg
+	pub keygen_msg: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Decode, Encode)]
+#[cfg_attr(feature = "scale-info", derive(scale_info::TypeInfo))]
+pub struct DKGOfflineMessage {
+	// Identifier
+	pub key: Vec<u8>,
+	/// Signer set epoch id
+	pub signer_set_id: SignerSetId,
+	/// Serialized offline stage msg
+	pub offline_msg: Vec<u8>,
+	/// Index in async protocols
+	pub async_index: u8,
+}
+
+#[derive(Debug, Clone, Decode, Encode)]
+#[cfg_attr(feature = "scale-info", derive(scale_info::TypeInfo))]
+pub struct DKGVoteMessage {
+	/// Party index
+	pub party_ind: u16,
+	/// Key for the vote signature created for
+	pub round_key: Vec<u8>,
+	/// Serialized partial signature
+	pub partial_signature: Vec<u8>,
+	/// Index in async protocols
+	pub async_index: u8,
+}
+
+#[derive(Debug, Clone, Decode, Encode)]
+#[cfg_attr(feature = "scale-info", derive(scale_info::TypeInfo))]
+pub struct DKGSignedPayload {
+	/// Payload key
+	pub key: Vec<u8>,
+	/// The payload signatures are collected for.
+	pub payload: Vec<u8>,
+	/// Runtime compatible signature for the payload
+	pub signature: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Decode, Encode)]
+#[cfg_attr(feature = "scale-info", derive(scale_info::TypeInfo))]
+pub struct PublicKeyMessage {
+	/// Round ID of DKG protocol
+	pub session_id: SessionId,
+	/// Public key for the DKG
+	pub pub_key: Vec<u8>,
+	/// Authority's signature for this public key
+	pub signature: Vec<u8>,
+}
+
+/// A misbehaviour message for reporting misbehaviour of an authority.
+#[derive(Debug, Clone, Decode, Encode)]
+#[cfg_attr(feature = "scale-info", derive(scale_info::TypeInfo))]
+pub struct MisbehaviourMessage {
+	/// Offending type
+	pub misbehaviour_type: MisbehaviourType,
+	/// Misbehaving round
+	pub session_id: SessionId,
+	/// Offending authority's id
+	pub offender: AuthorityId,
+	/// Authority's signature for this report
+	pub signature: Vec<u8>,
+}
+
+/// A vote message for voting on a new governor for cross-chain applications leveraging the DKG.
+/// https://github.com/webb-tools/protocol-solidity/blob/main/packages/contracts/contracts/utils/Governable.sol#L46-L53C3
+#[derive(Debug, Clone, Decode, Encode)]
+#[cfg_attr(feature = "scale-info", derive(scale_info::TypeInfo))]
+pub struct ProposerVoteMessage {
+	/// Round ID of DKG protocol
+	pub session_id: SessionId,
+	/// The leaf index of the proposer
+	pub proposer_leaf_index: u32,
+	/// The proposed governor
+	pub new_governor: Vec<u8>,
+	/// The merkle path sibling nodes for the proposer in the proposer set merkle tree
+	pub proposer_merkle_path: Vec<[u8; 32]>,
+	/// Authority's signature for this vote
+	pub signature: Vec<u8>,
+}

--- a/dkg-runtime-primitives/src/lib.rs
+++ b/dkg-runtime-primitives/src/lib.rs
@@ -107,7 +107,7 @@ pub type MaxReporters = CustomU32Getter<100>;
 /// Max size for signatures
 pub type MaxSignatureLength = CustomU32Getter<512>;
 
-/// Max size for signatures
+/// Max size for keys
 pub type MaxKeyLength = CustomU32Getter<512>;
 
 /// Max votes to store onchain
@@ -155,6 +155,25 @@ pub struct AggregatedMisbehaviourReports<
 	pub reporters: BoundedVec<DKGId, MaxReporters>,
 	/// A list of signed reports
 	pub signatures: BoundedVec<BoundedVec<u8, MaxSignatureLength>, MaxReporters>,
+}
+
+#[derive(Eq, PartialEq, Clone, Encode, Decode, Debug, TypeInfo, codec::MaxEncodedLen)]
+pub struct AggregatedProposerSetVotes<
+	DKGId: AsRef<[u8]>,
+	MaxSignatureLength: Get<u32> + Debug + Clone + TypeInfo,
+	MaxVoters: Get<u32> + Debug + Clone + TypeInfo,
+	VoteLength: Get<u32> + Debug + Clone + TypeInfo,
+> {
+	/// The round id the proposer vote is valid for.
+	pub session_id: u64,
+	/// The proposer
+	pub proposer: DKGId,
+	/// The encoded vote
+	pub vote: BoundedVec<u8, VoteLength>,
+	/// A list of voters
+	pub voters: BoundedVec<DKGId, MaxVoters>,
+	/// A list of signed encoded votes
+	pub signatures: BoundedVec<BoundedVec<u8, MaxSignatureLength>, MaxVoters>,
 }
 
 impl<BlockNumber, MaxLength: Get<u32>> Default for OffchainSignedProposals<BlockNumber, MaxLength> {
@@ -318,5 +337,7 @@ sp_api::decl_runtime_apis! {
 		fn refresh_nonce() -> u32;
 		/// Returns true if we should execute an new keygen.
 		fn should_execute_new_keygen() -> bool;
+		/// Returns true if we should execute an proposer set voting protocol.
+		fn should_submit_proposer_set_vote() -> bool;
 	}
 }

--- a/dkg-runtime-primitives/src/offchain/storage_keys.rs
+++ b/dkg-runtime-primitives/src/offchain/storage_keys.rs
@@ -46,6 +46,12 @@ pub const AGGREGATED_MISBEHAVIOUR_REPORTS: &[u8] = b"dkg-metadata::misbehaviour"
 // Lock Key for offchain storage of aggregated derived public keys
 pub const AGGREGATED_MISBEHAVIOUR_REPORTS_LOCK: &[u8] = b"dkg-metadata::misbehaviour::lock";
 
+// Key for offchain storage of aggregated proposer votes
+pub const AGGREGATED_PROPOSER_VOTES: &[u8] = b"dkg-metadata::proposer_votes";
+
+// Lock Key for offchain storage of aggregated proposer votes
+pub const AGGREGATED_PROPOSER_VOTES_LOCK: &[u8] = b"dkg-metadata::proposer_votes::lock";
+
 // Lock Key for submitting signed proposal on chain
 pub const SUBMIT_SIGNED_PROPOSAL_ON_CHAIN_LOCK: &[u8] =
 	b"dkg-proposal-handler::submit_signed_proposal_on_chain::lock";

--- a/dkg-runtime-primitives/src/traits.rs
+++ b/dkg-runtime-primitives/src/traits.rs
@@ -13,28 +13,39 @@
 // limitations under the License.
 //
 use frame_support::dispatch::DispatchResultWithPostInfo;
+use sp_runtime::BoundedVec;
 use sp_std::vec::Vec;
 
 pub trait OnAuthoritySetChangeHandler<AccountId, AuthoritySetId, AuthorityId> {
-	fn on_authority_set_changed(
-		authority_accounts: Vec<AccountId>,
-		authority_ids: Vec<AuthorityId>,
-	);
+	fn on_authority_set_changed(authority_accounts: &[AccountId], authority_ids: &[AuthorityId]);
 }
 
 impl<AccountId, AuthoritySetId, AuthorityId>
 	OnAuthoritySetChangeHandler<AccountId, AuthoritySetId, AuthorityId> for ()
 {
-	fn on_authority_set_changed(
-		_authority_accounts: Vec<AccountId>,
-		_authority_ids: Vec<AuthorityId>,
-	) {
+	fn on_authority_set_changed(_authority_accounts: &[AccountId], _authority_ids: &[AuthorityId]) {
 	}
 }
 
+/// A trait for fetching the current and pravious DKG Public Key.
 pub trait GetDKGPublicKey {
 	fn dkg_key() -> Vec<u8>;
 	fn previous_dkg_key() -> Vec<u8>;
+}
+
+/// A trait for fetching the current proposer set.
+pub trait GetProposerSet<AccountId, Bound> {
+	fn get_previous_proposer_set() -> Vec<AccountId>;
+	fn get_previous_external_proposer_accounts() -> Vec<(AccountId, BoundedVec<u8, Bound>)>;
+}
+
+impl<A, B> GetProposerSet<A, B> for () {
+	fn get_previous_proposer_set() -> Vec<A> {
+		Vec::new()
+	}
+	fn get_previous_external_proposer_accounts() -> Vec<(A, BoundedVec<u8, B>)> {
+		Vec::new()
+	}
 }
 
 /// A trait for when the DKG Public Key get changed.

--- a/pallets/dkg-metadata/src/lib.rs
+++ b/pallets/dkg-metadata/src/lib.rs
@@ -102,11 +102,11 @@ use dkg_runtime_primitives::{
 		OFFCHAIN_PUBLIC_KEY_SIG, OFFCHAIN_PUBLIC_KEY_SIG_LOCK, SUBMIT_GENESIS_KEYS_AT,
 		SUBMIT_KEYS_AT,
 	},
-	traits::{GetDKGPublicKey, OnAuthoritySetChangeHandler},
+	traits::{GetDKGPublicKey, GetProposerSet, OnAuthoritySetChangeHandler},
 	utils::{ecdsa, to_slice_33, verify_signer_from_set_ecdsa},
-	AggregatedMisbehaviourReports, AggregatedPublicKeys, AuthorityIndex, AuthoritySet,
-	ConsensusLog, MisbehaviourType, ProposalHandlerTrait, RefreshProposal, RefreshProposalSigned,
-	DKG_ENGINE_ID,
+	AggregatedMisbehaviourReports, AggregatedProposerSetVotes, AggregatedPublicKeys,
+	AuthorityIndex, AuthoritySet, ConsensusLog, MisbehaviourType, ProposalHandlerTrait,
+	RefreshProposal, RefreshProposalSigned, DKG_ENGINE_ID,
 };
 use frame_support::{
 	dispatch::DispatchResultWithPostInfo,
@@ -212,11 +212,16 @@ pub mod pallet {
 			Self::DKGId,
 		>;
 
+		/// Utility trait for handling DKG public key changes
 		type OnDKGPublicKeyChangeHandler: OnDKGPublicKeyChangeHandler<
 			dkg_runtime_primitives::AuthoritySetId,
 		>;
 
+		/// Proposer handler trait
 		type ProposalHandler: ProposalHandlerTrait;
+
+		/// Trait for fetching proposer set data
+		type ProposerSetView: GetProposerSet<Self::AccountId, Self::MaxKeyLength>;
 
 		/// A type that gives allows the pallet access to the session progress
 		type NextSessionRotation: EstimateNextSessionRotation<Self::BlockNumber>;
@@ -284,6 +289,19 @@ pub mod pallet {
 		/// Max reporters to store
 		#[pallet::constant]
 		type MaxReporters: Get<u32>
+			+ Default
+			+ TypeInfo
+			+ MaxEncodedLen
+			+ Debug
+			+ Clone
+			+ Eq
+			+ PartialEq
+			+ PartialOrd
+			+ Ord;
+
+		/// Length of encoded proposer vote
+		#[pallet::constant]
+		type VoteLength: Get<u32>
 			+ Default
 			+ TypeInfo
 			+ MaxEncodedLen
@@ -428,6 +446,11 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn should_execute_new_keygen)]
 	pub type ShouldExecuteNewKeygen<T: Config> = StorageValue<_, bool, ValueQuery>;
+
+	/// Should we submit a vote for the new DKG governor if we are a proposer
+	#[pallet::storage]
+	#[pallet::getter(fn should_submit_proposer_vote)]
+	pub type ShouldSubmitProposerVote<T: Config> = StorageValue<_, bool, ValueQuery>;
 
 	/// Holds public key for next session
 	#[pallet::storage]
@@ -680,6 +703,8 @@ pub mod pallet {
 			reporters: Vec<T::DKGId>,
 			offender: T::DKGId,
 		},
+		/// Proposer votes submitted
+		ProposerSetVotesSubmitted { voters: Vec<T::DKGId>, signatures: Vec<Vec<u8>>, vote: Vec<u8> },
 		/// Refresh DKG Keys Finished (forcefully).
 		RefreshKeysFinished { next_authority_set_id: dkg_runtime_primitives::AuthoritySetId },
 		/// NextKeygenThreshold updated
@@ -1233,6 +1258,37 @@ pub mod pallet {
 			Err(Error::<T>::InvalidMisbehaviourReports.into())
 		}
 
+		/// Submits an aggregated proposer vote signature to the chain.
+		/// This can be submitted by anyone. The signatures must be valid against
+		/// the current set of proposers.
+		///
+		/// The purpose of this extrinsic is to jumpstart the automation of the
+		/// proposer set update process on any cross-chain application leveraging the
+		/// DKG. When the DKG fails to rotate, the proposer set will eventually have the
+		/// opportunity to reset the state of any application that relies on the DKG for
+		/// governance.
+		#[pallet::weight(0)]
+		#[pallet::call_index(7)]
+		pub fn submit_proposer_set_votes(
+			origin: OriginFor<T>,
+			votes: AggregatedProposerSetVotes<
+				T::DKGId,
+				T::MaxSignatureLength,
+				T::MaxReporters,
+				T::VoteLength,
+			>,
+		) -> DispatchResultWithPostInfo {
+			ensure_none(origin)?;
+			let _valid_voters = Self::process_proposer_votes(votes);
+			// Self::deposit_event(Event::ProposerSetVotesSubmitted {
+			// 	signatures: votes.signatures,
+			// 	voters: valid_voters,
+			// 	vote: votes.vote,
+			// });
+
+			Ok(().into())
+		}
+
 		/// Attempts to remove an authority from all possible jails (keygen & signing).
 		/// This can only be called by the controller of the authority in jail. The
 		/// origin must map directly to the authority in jail.
@@ -1242,7 +1298,7 @@ pub mod pallet {
 		///
 		/// * `origin` - The account origin.
 		#[pallet::weight(<T as Config>::WeightInfo::unjail())]
-		#[pallet::call_index(7)]
+		#[pallet::call_index(8)]
 		pub fn unjail(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			let origin = ensure_signed(origin)?;
 			let authority =
@@ -1270,7 +1326,7 @@ pub mod pallet {
 		/// * `origin` - The account origin.
 		/// * `authority` - The authority to be removed from the keygen jail.
 		#[pallet::weight(<T as Config>::WeightInfo::force_unjail_keygen())]
-		#[pallet::call_index(8)]
+		#[pallet::call_index(9)]
 		pub fn force_unjail_keygen(
 			origin: OriginFor<T>,
 			authority: T::DKGId,
@@ -1288,7 +1344,7 @@ pub mod pallet {
 		/// * `origin` - The account origin.
 		/// * `authority` - The authority to be removed from the signing jail.
 		#[pallet::weight(<T as Config>::WeightInfo::force_unjail_signing())]
-		#[pallet::call_index(9)]
+		#[pallet::call_index(10)]
 		pub fn force_unjail_signing(
 			origin: OriginFor<T>,
 			authority: T::DKGId,
@@ -1305,7 +1361,7 @@ pub mod pallet {
 		/// automatically increments the authority ID. It uses `change_authorities`
 		/// to execute the rotation forcefully.
 		#[pallet::weight(0)]
-		#[pallet::call_index(10)]
+		#[pallet::call_index(11)]
 		pub fn force_change_authorities(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			T::ForceOrigin::ensure_origin(origin)?;
 			let next_authorities = NextAuthorities::<T>::get();
@@ -1323,6 +1379,7 @@ pub mod pallet {
 			// to sign our own key as a means of jumpstarting the mechanism.
 			if let Some(pub_key) = next_pub_key {
 				RefreshInProgress::<T>::put(true);
+				ShouldSubmitProposerVote::<T>::put(true);
 				let uncompressed_pub_key =
 					Self::decompress_public_key(pub_key.1.into()).unwrap_or_default();
 				let next_nonce = Self::refresh_nonce() + 1u32;
@@ -1351,7 +1408,7 @@ pub mod pallet {
 		///
 		/// Note that, this will clear the next public key and its signature, if any.
 		#[pallet::weight(0)]
-		#[pallet::call_index(11)]
+		#[pallet::call_index(12)]
 		pub fn trigger_emergency_keygen(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			T::ForceOrigin::ensure_origin(origin)?;
 			// Clear the next public key, if any, to ensure that the keygen protocol runs and we
@@ -1573,10 +1630,13 @@ impl<T: Config> Pallet<T> {
 			signed_payload.extend_from_slice(reports.session_id.to_be_bytes().as_ref());
 			signed_payload.extend_from_slice(reports.offender.as_ref());
 
-			// TODO: Verify signer from set over the best authorities set (compute it on chain)
 			let verifying_set: Vec<ecdsa::Public> = verifying_set
 				.iter()
-				.map(|x| ecdsa::Public(to_slice_33(&x.encode()).unwrap_or([0u8; 33])))
+				.map(|x| match to_slice_33(x.encode().as_ref()) {
+					Some(x) => ecdsa::Public(x),
+					None => ecdsa::Public([0u8; 33]),
+				})
+				.filter(|x| x.0 != [0u8; 33])
 				.collect();
 			let (_, success) =
 				verify_signer_from_set_ecdsa(verifying_set, &signed_payload, signature);
@@ -1587,6 +1647,40 @@ impl<T: Config> Pallet<T> {
 		}
 
 		valid_reporters
+	}
+
+	pub fn process_proposer_votes(
+		votes: AggregatedProposerSetVotes<
+			T::DKGId,
+			T::MaxSignatureLength,
+			T::MaxReporters,
+			T::VoteLength,
+		>,
+	) -> Vec<T::DKGId> {
+		let mut valid_voters = Vec::new();
+		for (inx, signature) in votes.signatures.iter().enumerate() {
+			let mut signed_payload = Vec::new();
+			signed_payload.extend_from_slice(votes.vote.as_ref());
+			let previous_proposer_set: Vec<ecdsa::Public> =
+				T::ProposerSetView::get_previous_external_proposer_accounts()
+					.iter()
+					.map(|x: &(T::AccountId, BoundedVec<u8, T::MaxKeyLength>)| {
+						match to_slice_33(x.1.encode().as_ref()) {
+							Some(x) => ecdsa::Public(x),
+							None => ecdsa::Public([0u8; 33]),
+						}
+					})
+					.filter(|x| x.0 != [0u8; 33])
+					.collect();
+			let (_, success) =
+				verify_signer_from_set_ecdsa(previous_proposer_set, &signed_payload, signature);
+
+			if success && !valid_voters.contains(&votes.voters[inx]) {
+				valid_voters.push(votes.voters[inx].clone());
+			}
+		}
+
+		valid_voters
 	}
 
 	pub fn store_consensus_log(
@@ -1628,7 +1722,7 @@ impl<T: Config> Pallet<T> {
 			T::AccountId,
 			dkg_runtime_primitives::AuthoritySetId,
 			T::DKGId,
-		>>::on_authority_set_changed(new_authorities_accounts.clone(), new_authority_ids.clone());
+		>>::on_authority_set_changed(&new_authorities_accounts, &new_authority_ids);
 		// Set refresh in progress to false
 		RefreshInProgress::<T>::put(false);
 		// Update the next thresholds for the next session
@@ -1801,7 +1895,7 @@ impl<T: Config> Pallet<T> {
 			T::AccountId,
 			dkg_runtime_primitives::AuthoritySetId,
 			T::DKGId,
-		>>::on_authority_set_changed(authority_account_ids.to_vec(), authorities.to_vec());
+		>>::on_authority_set_changed(authority_account_ids, authorities);
 	}
 
 	/// An offchain function that collects the genesis DKG public key

--- a/pallets/dkg-metadata/src/lib.rs
+++ b/pallets/dkg-metadata/src/lib.rs
@@ -104,9 +104,9 @@ use dkg_runtime_primitives::{
 	},
 	traits::{GetDKGPublicKey, GetProposerSet, OnAuthoritySetChangeHandler},
 	utils::{ecdsa, to_slice_33, verify_signer_from_set_ecdsa},
-	AggregatedMisbehaviourReports, AggregatedProposerSetVotes, AggregatedPublicKeys,
-	AuthorityIndex, AuthoritySet, ConsensusLog, MisbehaviourType, ProposalHandlerTrait,
-	RefreshProposal, RefreshProposalSigned, DKG_ENGINE_ID,
+	AggregatedMisbehaviourReports, AggregatedProposerVotes, AggregatedPublicKeys, AuthorityIndex,
+	AuthoritySet, ConsensusLog, MisbehaviourType, ProposalHandlerTrait, RefreshProposal,
+	RefreshProposalSigned, DKG_ENGINE_ID,
 };
 use frame_support::{
 	dispatch::DispatchResultWithPostInfo,
@@ -1271,7 +1271,7 @@ pub mod pallet {
 		#[pallet::call_index(7)]
 		pub fn submit_proposer_set_votes(
 			origin: OriginFor<T>,
-			votes: AggregatedProposerSetVotes<
+			votes: AggregatedProposerVotes<
 				T::DKGId,
 				T::MaxSignatureLength,
 				T::MaxReporters,
@@ -1650,7 +1650,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	pub fn process_proposer_votes(
-		votes: AggregatedProposerSetVotes<
+		votes: AggregatedProposerVotes<
 			T::DKGId,
 			T::MaxSignatureLength,
 			T::MaxReporters,
@@ -1660,7 +1660,7 @@ impl<T: Config> Pallet<T> {
 		let mut valid_voters = Vec::new();
 		for (inx, signature) in votes.signatures.iter().enumerate() {
 			let mut signed_payload = Vec::new();
-			signed_payload.extend_from_slice(votes.vote.as_ref());
+			signed_payload.extend_from_slice(votes.encoded_vote.as_ref());
 			let previous_proposer_set: Vec<ecdsa::Public> =
 				T::ProposerSetView::get_previous_external_proposer_accounts()
 					.iter()

--- a/pallets/dkg-metadata/src/mock.rs
+++ b/pallets/dkg-metadata/src/mock.rs
@@ -14,6 +14,7 @@
 
 // construct_runtime requires this
 #![allow(clippy::from_over_into, clippy::unwrap_used)]
+use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
 	construct_runtime, parameter_types, sp_io::TestExternalities, traits::GenesisBuild,
 	BasicExternalities,
@@ -126,6 +127,11 @@ where
 	}
 }
 
+parameter_types! {
+	#[derive(Default, Clone, Encode, Decode, Debug, Eq, PartialEq, scale_info::TypeInfo, Ord, PartialOrd, MaxEncodedLen)]
+	pub const VoteLength: u32 = 64;
+}
+
 impl pallet_dkg_metadata::Config for Test {
 	type DKGId = DKGId;
 	type RuntimeEvent = RuntimeEvent;
@@ -148,6 +154,8 @@ impl pallet_dkg_metadata::Config for Test {
 	type MaxSignatureLength = MaxSignatureLength;
 	type MaxReporters = MaxReporters;
 	type MaxAuthorities = MaxAuthorities;
+	type VoteLength = VoteLength;
+	type ProposerSetView = ();
 	type WeightInfo = ();
 }
 

--- a/pallets/dkg-proposal-handler/src/mock.rs
+++ b/pallets/dkg-proposal-handler/src/mock.rs
@@ -14,7 +14,7 @@
 //
 #![allow(clippy::unwrap_used)]
 use crate as pallet_dkg_proposal_handler;
-use codec::{Decode, Encode};
+use codec::{Decode, Encode, MaxEncodedLen};
 pub use dkg_runtime_primitives::{
 	crypto::AuthorityId as DKGId, ConsensusLog, MaxAuthorities, MaxKeyLength, MaxReporters,
 	MaxSignatureLength, DKG_ENGINE_ID,
@@ -22,7 +22,7 @@ pub use dkg_runtime_primitives::{
 use frame_support::{parameter_types, traits::Everything, BoundedVec, PalletId};
 use frame_system as system;
 use frame_system::EnsureRoot;
-use pallet_dkg_proposals::DKGEcdsaToEthereum;
+use pallet_dkg_proposals::DKGEcdsaToEthereumAddress;
 use sp_core::{sr25519::Signature, H256};
 use sp_runtime::{
 	impl_opaque_keys,
@@ -166,9 +166,7 @@ where
 
 parameter_types! {
 	#[derive(Clone, Encode, Decode, Debug, Eq, PartialEq, scale_info::TypeInfo, Ord, PartialOrd)]
-	pub const MaxAuthorityProposers : u32 = 100;
-	#[derive(Clone, Encode, Decode, Debug, Eq, PartialEq, scale_info::TypeInfo, Ord, PartialOrd)]
-	pub const MaxExternalProposerAccounts : u32 = 100;
+	pub const MaxProposers : u32 = 100;
 }
 
 impl pallet_dkg_proposal_handler::Config for Test {
@@ -184,7 +182,7 @@ impl pallet_dkg_proposal_handler::Config for Test {
 
 impl pallet_dkg_proposals::Config for Test {
 	type AdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
-	type DKGAuthorityToMerkleLeaf = DKGEcdsaToEthereum;
+	type DKGAuthorityToMerkleLeaf = DKGEcdsaToEthereumAddress;
 	type DKGId = DKGId;
 	type ChainIdentifier = ChainIdentifier;
 	type MaxProposalLength = MaxProposalLength;
@@ -195,8 +193,8 @@ impl pallet_dkg_proposals::Config for Test {
 	type Period = Period;
 	type MaxVotes = MaxVotes;
 	type MaxResources = MaxResources;
-	type MaxAuthorityProposers = MaxAuthorityProposers;
-	type MaxExternalProposerAccounts = MaxExternalProposerAccounts;
+	type MaxProposers = MaxProposers;
+	type ExternalProposerAccountSize = MaxKeyLength;
 	type WeightInfo = ();
 }
 
@@ -243,6 +241,11 @@ impl pallet_session::Config for Test {
 	type WeightInfo = ();
 }
 
+parameter_types! {
+	#[derive(Default, Clone, Encode, Decode, Debug, Eq, PartialEq, scale_info::TypeInfo, Ord, PartialOrd, MaxEncodedLen)]
+	pub const VoteLength: u32 = 64;
+}
+
 impl pallet_dkg_metadata::Config for Test {
 	type DKGId = DKGId;
 	type RuntimeEvent = RuntimeEvent;
@@ -265,6 +268,8 @@ impl pallet_dkg_metadata::Config for Test {
 	type MaxSignatureLength = MaxSignatureLength;
 	type MaxReporters = MaxReporters;
 	type MaxAuthorities = MaxAuthorities;
+	type VoteLength = VoteLength;
+	type ProposerSetView = DKGProposals;
 	type WeightInfo = ();
 }
 

--- a/pallets/dkg-proposals/src/benchmarking.rs
+++ b/pallets/dkg-proposals/src/benchmarking.rs
@@ -97,28 +97,6 @@ benchmarks! {
 		assert_last_event::<T>(Event::ChainWhitelisted{ chain_id}.into());
 	}
 
-	add_proposer {
-		let admin = RawOrigin::Root;
-		let v: T::AccountId = account("account", 0, SEED);
-		let another = vec![1u8, 2, 3];
-
-
-	}: _(admin, v.clone(), another)
-	verify {
-		assert_last_event::<T>(Event::ProposerAdded{ proposer_id: v}.into());
-	}
-
-	remove_proposer {
-		let admin = RawOrigin::Root;
-		let v: T::AccountId = account("account", 0, SEED);
-		let another = vec![1u8, 2, 3];
-
-		crate::Pallet::<T>::register_proposer(v.clone(), another).unwrap();
-	}: _(admin, v.clone())
-	verify {
-		assert_last_event::<T>(Event::ProposerRemoved{ proposer_id: v}.into());
-	}
-
 	acknowledge_proposal {
 		let c in 1 .. 500;
 		let caller: T::AccountId = whitelisted_caller();
@@ -132,12 +110,14 @@ benchmarks! {
 			kind: ProposalKind::AnchorUpdate,
 			data: vec![].try_into().unwrap(),
 		});
-		Proposers::<T>::insert(caller.clone(), true);
+		let mut proposers: BoundedVec<T::AccountId, T::MaxProposers> = vec![caller.clone()].try_into().expect("Failed to create proposers");
+		Proposers::<T>::put(proposers.clone());
 		Pallet::<T>::whitelist(chain_id).unwrap();
 		Pallet::<T>::set_proposer_threshold(10).unwrap();
 		for i in 1..9 {
 			let who: T::AccountId = account("account", i, SEED);
-			Proposers::<T>::insert(who.clone(), true);
+			proposers.try_push(who.clone()).expect("Failed to push proposer");
+			Proposers::<T>::put(proposers.clone());
 			Pallet::<T>::commit_vote(who, i.into(), chain_id, &proposal, true).unwrap();
 		}
 	}: _(RawOrigin::Signed(caller.clone()), nonce.into(), chain_id,  resource_id, proposal.clone())
@@ -159,12 +139,14 @@ benchmarks! {
 			kind: ProposalKind::AnchorUpdate,
 			data: vec![].try_into().unwrap(),
 		});
-		Proposers::<T>::insert(caller.clone(), true);
+		let mut proposers: BoundedVec<T::AccountId, T::MaxProposers> = vec![caller.clone()].try_into().expect("Failed to create proposers");
+		Proposers::<T>::put(proposers.clone());
 		Pallet::<T>::whitelist(chain_id).unwrap();
 		Pallet::<T>::set_proposer_threshold(10).unwrap();
 		for i in 1..9 {
 			let who: T::AccountId = account("account", i, SEED);
-			Proposers::<T>::insert(who.clone(), true);
+			proposers.try_push(who.clone()).expect("Failed to push proposer");
+			Proposers::<T>::put(proposers.clone());
 			Pallet::<T>::commit_vote(who, i.into(), chain_id, &proposal, false).unwrap();
 		}
 	}: _(RawOrigin::Signed(caller.clone()), nonce.into(), chain_id,  resource_id, proposal.clone())
@@ -184,12 +166,14 @@ benchmarks! {
 			kind: ProposalKind::AnchorUpdate,
 			data: vec![].try_into().unwrap(),
 		});
-		Proposers::<T>::insert(caller.clone(), true);
+		let mut proposers: BoundedVec<T::AccountId, T::MaxProposers> = vec![caller.clone()].try_into().expect("Failed to create proposers");
+		Proposers::<T>::put(proposers.clone());
 		Pallet::<T>::whitelist(chain_id).unwrap();
 		Pallet::<T>::set_proposer_threshold(10).unwrap();
 		for i in 1..9 {
 			let who: T::AccountId = account("account", i, SEED);
-			Proposers::<T>::insert(who.clone(), true);
+			proposers.try_push(who.clone()).expect("Failed to push proposer");
+			Proposers::<T>::put(proposers.clone());
 			Pallet::<T>::commit_vote(who, i.into(), chain_id, &proposal, false).unwrap();
 		}
 

--- a/pallets/dkg-proposals/src/lib.rs
+++ b/pallets/dkg-proposals/src/lib.rs
@@ -851,7 +851,7 @@ impl<T: Config> Pallet<T> {
 	/// It is expected that the size of the returned vector is a power of 2.
 	pub fn pre_process_for_merkleize() -> Vec<[u8; 32]> {
 		let height = Self::get_proposer_set_tree_height();
-		// Check for each key that the proposer is valid (should return true)
+		// Hash the external accounts into 32 byte chunks to form the base layer of the merkle tree
 		let mut base_layer: Vec<[u8; 32]> = ExternalProposerAccounts::<T>::get()
 			.into_iter()
 			.map(|accounts| keccak_256(&accounts.1))

--- a/pallets/dkg-proposals/src/weights.rs
+++ b/pallets/dkg-proposals/src/weights.rs
@@ -35,8 +35,6 @@ pub trait WeightInfo {
 	fn set_resource(c: u32, ) -> Weight;
 	fn remove_resource() -> Weight;
 	fn whitelist_chain() -> Weight;
-	fn add_proposer() -> Weight;
-	fn remove_proposer() -> Weight;
 	fn acknowledge_proposal(c: u32, ) -> Weight;
 	fn reject_proposal(c: u32, ) -> Weight;
 	fn eval_vote_state(c: u32, ) -> Weight;
@@ -87,36 +85,6 @@ impl<T: frame_system::Config> WeightInfo for WebbWeight<T> {
 		Weight::from_parts(15_000_000, 2511)
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
-	}
-	/// Storage: DKGProposals Proposers (r:1 w:1)
-	/// Proof: DKGProposals Proposers (max_values: None, max_size: Some(49), added: 2524, mode: MaxEncodedLen)
-	/// Storage: DKGProposals ProposerCount (r:1 w:1)
-	/// Proof: DKGProposals ProposerCount (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
-	/// Storage: DKGProposals ExternalProposerAccounts (r:0 w:1)
-	/// Proof: DKGProposals ExternalProposerAccounts (max_values: None, max_size: Some(1050), added: 3525, mode: MaxEncodedLen)
-	fn add_proposer() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `375`
-		//  Estimated: `3023`
-		// Minimum execution time: 17_000_000 picoseconds.
-		Weight::from_parts(17_000_000, 3023)
-			.saturating_add(T::DbWeight::get().reads(2_u64))
-			.saturating_add(T::DbWeight::get().writes(3_u64))
-	}
-	/// Storage: DKGProposals Proposers (r:1 w:1)
-	/// Proof: DKGProposals Proposers (max_values: None, max_size: Some(49), added: 2524, mode: MaxEncodedLen)
-	/// Storage: DKGProposals ProposerCount (r:1 w:1)
-	/// Proof: DKGProposals ProposerCount (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
-	/// Storage: DKGProposals ExternalProposerAccounts (r:0 w:1)
-	/// Proof: DKGProposals ExternalProposerAccounts (max_values: None, max_size: Some(1050), added: 3525, mode: MaxEncodedLen)
-	fn remove_proposer() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `429`
-		//  Estimated: `3023`
-		// Minimum execution time: 22_000_000 picoseconds.
-		Weight::from_parts(22_000_000, 3023)
-			.saturating_add(T::DbWeight::get().reads(2_u64))
-			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
 	/// Storage: DKGProposals Proposers (r:1 w:0)
 	/// Proof: DKGProposals Proposers (max_values: None, max_size: Some(49), added: 2524, mode: MaxEncodedLen)
@@ -226,36 +194,6 @@ impl WeightInfo for () {
 		Weight::from_parts(15_000_000, 2511)
 			.saturating_add(RocksDbWeight::get().reads(1_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
-	}
-	/// Storage: DKGProposals Proposers (r:1 w:1)
-	/// Proof: DKGProposals Proposers (max_values: None, max_size: Some(49), added: 2524, mode: MaxEncodedLen)
-	/// Storage: DKGProposals ProposerCount (r:1 w:1)
-	/// Proof: DKGProposals ProposerCount (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
-	/// Storage: DKGProposals ExternalProposerAccounts (r:0 w:1)
-	/// Proof: DKGProposals ExternalProposerAccounts (max_values: None, max_size: Some(1050), added: 3525, mode: MaxEncodedLen)
-	fn add_proposer() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `375`
-		//  Estimated: `3023`
-		// Minimum execution time: 17_000_000 picoseconds.
-		Weight::from_parts(17_000_000, 3023)
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().writes(3_u64))
-	}
-	/// Storage: DKGProposals Proposers (r:1 w:1)
-	/// Proof: DKGProposals Proposers (max_values: None, max_size: Some(49), added: 2524, mode: MaxEncodedLen)
-	/// Storage: DKGProposals ProposerCount (r:1 w:1)
-	/// Proof: DKGProposals ProposerCount (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
-	/// Storage: DKGProposals ExternalProposerAccounts (r:0 w:1)
-	/// Proof: DKGProposals ExternalProposerAccounts (max_values: None, max_size: Some(1050), added: 3525, mode: MaxEncodedLen)
-	fn remove_proposer() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `429`
-		//  Estimated: `3023`
-		// Minimum execution time: 22_000_000 picoseconds.
-		Weight::from_parts(22_000_000, 3023)
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().writes(3_u64))
 	}
 	/// Storage: DKGProposals Proposers (r:1 w:0)
 	/// Proof: DKGProposals Proposers (max_values: None, max_size: Some(49), added: 2524, mode: MaxEncodedLen)

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -20,7 +20,7 @@
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
-use codec::{Decode, Encode};
+use codec::{Decode, Encode, MaxEncodedLen};
 use dkg_runtime_primitives::{
 	MaxAuthorities, MaxKeyLength, MaxProposalLength, MaxReporters, MaxSignatureLength,
 	TypedChainId, UnsignedProposal,


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- [x] In an effort to simplify operations of the bridge and handle the propser set voting protocol seamlessly, we make the restriction that proposers can only be active validators.
- [ ] We use the proposers to watch the chain in the event we `force_change_authorities`.
- [ ] If the `force_change_authorities` extrinsic is called, we have the proposers sign the `Vote` with their ECDSA keys and gossip similarly to how we gossip misbehaviours
- [ ] We store these votes for any relayer to grab and apply.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 
