### PR TITLE
Add`force_remove_unsigned_proposal` to remove unsigned proposal from storage

### DIFF
--- a/pallets/dkg-proposal-handler/src/benchmarking.rs
+++ b/pallets/dkg-proposal-handler/src/benchmarking.rs
@@ -91,18 +91,29 @@ benchmarks! {
 	}
 
 	force_submit_unsigned_proposal {
-
 		let buf = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 38, 87, 136, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0].to_vec();
 
 		let proposal = Proposal::Unsigned {
 			kind: ProposalKind::TokenAdd,
 			data: buf.try_into().unwrap()
 		};
-
 	}: _(RawOrigin::Root, proposal)
-
 	verify {
 		assert!(Pallet::<T>::get_unsigned_proposals().len() == 1);
+	}
+
+	force_remove_unsigned_proposal {
+		let buf = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 38, 87, 136, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0].to_vec();
+		let proposal = Proposal::Unsigned {
+			kind: ProposalKind::TokenAdd,
+			data: buf.try_into().unwrap()
+		};
+		Pallet::<T>::force_submit_unsigned_proposal(RawOrigin::Root.into(), proposal.clone()).unwrap();
+		assert!(Pallet::<T>::get_unsigned_proposals().len() == 1);
+		let prop_identifier = decode_proposal_identifier(&proposal).unwrap();
+	}: _(RawOrigin::Root, prop_identifier.typed_chain_id, prop_identifier.key)
+	verify {
+		assert!(Pallet::<T>::get_unsigned_proposals().len() == 0);
 	}
 
 }

--- a/pallets/dkg-proposal-handler/src/lib.rs
+++ b/pallets/dkg-proposal-handler/src/lib.rs
@@ -483,6 +483,10 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			// Call must come from root (likely from a democracy proposal passing)
 			<T as pallet::Config>::ForceOrigin::ensure_origin(origin)?;
+			ensure!(
+				UnsignedProposalQueue::<T>::contains_key(typed_chain_id, key),
+				Error::<T>::ProposalDoesNotExists
+			);
 			UnsignedProposalQueue::<T>::remove(typed_chain_id, key);
 			Self::deposit_event(Event::<T>::ProposalRemoved {
 				target_chain: typed_chain_id,

--- a/pallets/dkg-proposal-handler/src/lib.rs
+++ b/pallets/dkg-proposal-handler/src/lib.rs
@@ -361,7 +361,7 @@ pub mod pallet {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
-		#[pallet::weight(0)]
+		#[pallet::weight(<T as Config>::WeightInfo::submit_signed_proposals(props.len() as u32))]
 		#[pallet::call_index(0)]
 		#[frame_support::transactional]
 		pub fn submit_signed_proposals(
@@ -440,7 +440,7 @@ pub mod pallet {
 		/// There are certain proposals we'd like to be proposable only
 		/// through root actions. The currently supported proposals are
 		/// 	1. Updating
-		#[pallet::weight(1)]
+		#[pallet::weight(<T as Config>::WeightInfo::force_submit_unsigned_proposal())]
 		#[pallet::call_index(1)]
 		pub fn force_submit_unsigned_proposal(
 			origin: OriginFor<T>,
@@ -471,6 +471,25 @@ pub mod pallet {
 			} else {
 				Err(Error::<T>::ProposalMustBeUnsigned.into())
 			}
+		}
+
+		/// Force remove an unsigned proposal from the queue
+		#[pallet::weight(<T as Config>::WeightInfo::force_remove_unsigned_proposal())]
+		#[pallet::call_index(2)]
+		pub fn force_remove_unsigned_proposal(
+			origin: OriginFor<T>,
+			typed_chain_id: TypedChainId,
+			key: DKGPayloadKey,
+		) -> DispatchResultWithPostInfo {
+			// Call must come from root (likely from a democracy proposal passing)
+			<T as pallet::Config>::ForceOrigin::ensure_origin(origin)?;
+			UnsignedProposalQueue::<T>::remove(typed_chain_id, key);
+			Self::deposit_event(Event::<T>::ProposalRemoved {
+				target_chain: typed_chain_id,
+				key,
+				expired: false,
+			});
+			Ok(().into())
 		}
 	}
 

--- a/pallets/dkg-proposal-handler/src/weights.rs
+++ b/pallets/dkg-proposal-handler/src/weights.rs
@@ -33,6 +33,7 @@ use core::marker::PhantomData;
 pub trait WeightInfo {
 	fn submit_signed_proposals(n: u32, ) -> Weight;
 	fn force_submit_unsigned_proposal() -> Weight;
+	fn force_remove_unsigned_proposal() -> Weight;
 }
 
 /// Weights for pallet_dkg_proposal_handler using the Substrate node and recommended hardware.

--- a/pallets/dkg-proposal-handler/src/weights.rs
+++ b/pallets/dkg-proposal-handler/src/weights.rs
@@ -71,6 +71,16 @@ impl<T: frame_system::Config> WeightInfo for WebbWeight<T> {
 		Weight::from_parts(12_000_000, 0)
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
+	/// Storage: DKGProposalHandler UnsignedProposalQueue (r:0 w:1)
+	/// Proof: DKGProposalHandler UnsignedProposalQueue (max_values: None, max_size: Some(20052), added: 22527, mode: MaxEncodedLen)
+	fn force_remove_unsigned_proposal() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 12_000_000 picoseconds.
+		Weight::from_parts(12_000_000, 0)
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
 }
 
 // For backwards compatibility and tests
@@ -101,6 +111,16 @@ impl WeightInfo for () {
 	/// Storage: DKGProposalHandler UnsignedProposalQueue (r:0 w:1)
 	/// Proof: DKGProposalHandler UnsignedProposalQueue (max_values: None, max_size: Some(20052), added: 22527, mode: MaxEncodedLen)
 	fn force_submit_unsigned_proposal() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 12_000_000 picoseconds.
+		Weight::from_parts(12_000_000, 0)
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+	/// Storage: DKGProposalHandler UnsignedProposalQueue (r:0 w:1)
+	/// Proof: DKGProposalHandler UnsignedProposalQueue (max_values: None, max_size: Some(20052), added: 22527, mode: MaxEncodedLen)
+	fn force_remove_unsigned_proposal() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Adds `force_remove_unsigned_proposal` to remove unsigned proposal from storage

**Reference issue to close (if applicable)**
Closes #641 
