### PR TITLE
downgrade nightly to nightly-2023-01-26

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2023-06-01"
+channel = "nightly-2023-01-01"
 components = ["rustfmt", "clippy", "rust-src"]
 targets = ["wasm32-unknown-unknown"]
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2023-01-01"
+channel = "nightly-2023-01-26"
 components = ["rustfmt", "clippy", "rust-src"]
 targets = ["wasm32-unknown-unknown"]
 


### PR DESCRIPTION
Fixes substrate issue with latest nightly
https://substrate.stackexchange.com/questions/7714/cannot-run-substrate-on-a-fresh-macbook-m2