### PR TITLE
Add retry_id to DKG messages, add keygen message enqueueing

### DIFF
--- a/dkg-gadget/src/async_protocols/mod.rs
+++ b/dkg-gadget/src/async_protocols/mod.rs
@@ -76,6 +76,7 @@ pub struct AsyncProtocolParameters<
 	pub authority_public_key: Arc<Public>,
 	pub party_i: KeygenPartyId,
 	pub associated_block_id: u64,
+	pub retry_id: u16,
 	pub batch_id_gen: Arc<AtomicU64>,
 	pub handle: AsyncProtocolRemote<BI::Clock>,
 	pub session_id: SessionId,
@@ -144,6 +145,7 @@ impl<
 			handle: self.handle.clone(),
 			local_key: self.local_key.clone(),
 			db: self.db.clone(),
+			retry_id: self.retry_id,
 			logger: self.logger.clone(),
 		}
 	}
@@ -623,6 +625,7 @@ where
 				status,
 				payload,
 				session_id: params.session_id,
+				retry_id: params.retry_id,
 			};
 			if let Err(err) = params.engine.sign_and_send_msg(unsigned_dkg_message) {
 				params

--- a/dkg-gadget/src/async_protocols/remote.rs
+++ b/dkg-gadget/src/async_protocols/remote.rs
@@ -37,6 +37,7 @@ pub struct AsyncProtocolRemote<C> {
 	pub(crate) current_round_blame_tx: Arc<tokio::sync::watch::Sender<CurrentRoundBlame>>,
 	pub(crate) session_id: SessionId,
 	pub(crate) associated_block_id: u64,
+	pub(crate) retry_id: u16,
 	pub(crate) logger: DebugLogger,
 	status_history: Arc<Mutex<Vec<MetaHandlerStatus>>>,
 }
@@ -64,6 +65,7 @@ impl<C: Clone> Clone for AsyncProtocolRemote<C> {
 			logger: self.logger.clone(),
 			status_history: self.status_history.clone(),
 			associated_block_id: self.associated_block_id,
+			retry_id: self.retry_id,
 		}
 	}
 }
@@ -85,6 +87,7 @@ impl<C: AtLeast32BitUnsigned + Copy + Send> AsyncProtocolRemote<C> {
 		session_id: SessionId,
 		logger: DebugLogger,
 		associated_block_id: u64,
+		retry_id: u16,
 	) -> Self {
 		let (stop_tx, stop_rx) = tokio::sync::mpsc::unbounded_channel();
 		let (tx_keygen_signing, rx_keygen_signing) = tokio::sync::mpsc::unbounded_channel();
@@ -140,6 +143,7 @@ impl<C: AtLeast32BitUnsigned + Copy + Send> AsyncProtocolRemote<C> {
 			is_primary_remote: false,
 			session_id,
 			associated_block_id,
+			retry_id,
 		}
 	}
 

--- a/dkg-gadget/src/async_protocols/sign/handler.rs
+++ b/dkg-gadget/src/async_protocols/sign/handler.rs
@@ -231,6 +231,7 @@ where
 				status: DKGMsgStatus::ACTIVE,
 				payload,
 				session_id: params.session_id,
+				retry_id: 0,
 			};
 
 			// we have no synchronization mechanism post-offline stage. Sometimes, messages

--- a/dkg-gadget/src/gossip_messages/misbehaviour_report.rs
+++ b/dkg-gadget/src/gossip_messages/misbehaviour_report.rs
@@ -154,6 +154,7 @@ where
 			recipient_id: None,
 			status,
 			session_id: report.session_id,
+			retry_id: 0,
 			payload,
 		};
 		let encoded_dkg_message = message.encode();

--- a/dkg-gadget/src/gossip_messages/public_key_gossip.rs
+++ b/dkg-gadget/src/gossip_messages/public_key_gossip.rs
@@ -59,11 +59,11 @@ where
 			.logger
 			.debug(format!("SESSION {} | Received public key broadcast", msg.session_id));
 
-		let (is_main_round, is_genesis) = {
+		let is_main_round = {
 			if let Some(rounds) = dkg_worker.rounds.read().as_ref() {
-				(msg.session_id == rounds.session_id, rounds.session_id == 0)
+				msg.session_id == rounds.session_id
 			} else {
-				(false, false)
+				false
 			}
 		};
 
@@ -104,7 +104,7 @@ where
 			store_aggregated_public_keys::<B, C, BE, MaxProposalLength>(
 				&dkg_worker.backend,
 				&mut lock,
-				is_genesis,
+				is_main_round,
 				session_id,
 				current_block_number,
 				&dkg_worker.logger,

--- a/dkg-gadget/src/gossip_messages/public_key_gossip.rs
+++ b/dkg-gadget/src/gossip_messages/public_key_gossip.rs
@@ -93,9 +93,8 @@ where
 		}
 
 		dkg_worker.logger.debug(format!(
-			"SESSION {} | isGenesis? {} | Threshold {} | Aggregated pubkeys {}",
+			"SESSION {} | Threshold {} | Aggregated pubkeys {}",
 			msg.session_id,
-			is_genesis,
 			threshold,
 			aggregated_public_keys.keys_and_signatures.len()
 		));

--- a/dkg-gadget/src/storage/public_keys.rs
+++ b/dkg-gadget/src/storage/public_keys.rs
@@ -81,8 +81,9 @@ where
 			SUBMIT_KEYS_AT,
 			logger,
 		);
-		let _ = aggregated_public_keys.remove(&session_id);
 	}
+
+	let _ = aggregated_public_keys.remove(&session_id);
 
 	Ok(())
 }

--- a/dkg-gadget/src/storage/public_keys.rs
+++ b/dkg-gadget/src/storage/public_keys.rs
@@ -81,9 +81,8 @@ where
 			SUBMIT_KEYS_AT,
 			logger,
 		);
+		let _ = aggregated_public_keys.remove(&session_id);
 	}
-
-	let _ = aggregated_public_keys.remove(&session_id);
 
 	Ok(())
 }

--- a/dkg-gadget/src/worker.rs
+++ b/dkg-gadget/src/worker.rs
@@ -27,17 +27,17 @@ use sp_consensus::SyncOracle;
 use crate::signing_manager::SigningManager;
 use futures::StreamExt;
 use multi_party_ecdsa::protocols::multi_party_ecdsa::gg_2020::state_machine::keygen::LocalKey;
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use sc_client_api::{Backend, FinalityNotification};
 use sc_keystore::LocalKeystore;
 use sp_arithmetic::traits::SaturatedConversion;
 use sp_core::ecdsa;
 use sp_runtime::traits::{Block, Get, Header, NumberFor};
 use std::{
-	collections::{BTreeSet, HashMap, HashSet},
+	collections::{BTreeSet, HashMap, HashSet, VecDeque},
 	marker::PhantomData,
 	sync::{
-		atomic::{AtomicUsize, Ordering},
+		atomic::{AtomicU16, Ordering},
 		Arc,
 	},
 };
@@ -146,15 +146,19 @@ where
 	/// For transmitting errors from parallel threads to the DKGWorker
 	pub error_handler: tokio::sync::broadcast::Sender<DKGError>,
 	/// Keep track of the number of how many times we have tried the keygen protocol.
-	pub keygen_retry_count: Arc<AtomicUsize>,
+	pub keygen_retry_count: Arc<AtomicU16>,
 	/// Used to keep track of network status
 	pub network: Option<Arc<NetworkService<B, B::Hash>>>,
 	pub test_bundle: Option<TestBundle>,
 	pub logger: DebugLogger,
 	pub signing_manager: SigningManager<B, BE, C, GE>,
+	pub keygen_enqueued_messages: KeygenEnqueuedMessages,
 	// keep rustc happy
 	_backend: PhantomData<(BE, MaxProposalLength)>,
 }
+
+type KeygenEnqueuedMessages =
+	Arc<Mutex<HashMap<u64, HashMap<u16, VecDeque<SignedDKGMessage<Public>>>>>>;
 
 /// Used only for tests
 #[derive(Clone)]
@@ -200,6 +204,7 @@ where
 			network: self.network.clone(),
 			logger: self.logger.clone(),
 			signing_manager: self.signing_manager.clone(),
+			keygen_enqueued_messages: self.keygen_enqueued_messages.clone(),
 			_backend: PhantomData,
 		}
 	}
@@ -263,9 +268,10 @@ where
 			aggregated_misbehaviour_reports: Arc::new(RwLock::new(HashMap::new())),
 			currently_signing_proposals: Arc::new(RwLock::new(HashSet::new())),
 			local_keystore: Arc::new(RwLock::new(local_keystore)),
+			keygen_enqueued_messages: Arc::new(Mutex::new(Default::default())),
 			test_bundle,
 			error_handler,
-			keygen_retry_count: Arc::new(AtomicUsize::new(0)),
+			keygen_retry_count: Arc::new(AtomicU16::new(0)),
 			logger,
 			network,
 			signing_manager,
@@ -314,19 +320,26 @@ where
 
 		let now = self.get_latest_block_number();
 		let associated_block_id: u64 = associated_block.saturated_into();
-		let mut status_handle =
-			AsyncProtocolRemote::new(now, session_id, self.logger.clone(), associated_block_id);
 		// Fetch the active key. This requires rotating the key to have happened with
 		// full certainty in order to ensure the right key is being used to make signatures.
-		let active_local_key = match stage {
-			ProtoStageType::Genesis => None,
-			ProtoStageType::Queued => None,
+		let keygen_retry_id = self.keygen_retry_count.load(Ordering::Relaxed);
+		let (active_local_key, retry_id) = match stage {
+			ProtoStageType::Genesis => (None, keygen_retry_id),
+			ProtoStageType::Queued => (None, keygen_retry_id),
 			ProtoStageType::Signing { .. } => {
 				let optional_session_id = Some(session_id);
 				let (active_local_key, _) = self.fetch_local_keys(optional_session_id);
-				active_local_key
+				(active_local_key, 0)
 			},
 		};
+		let mut status_handle = AsyncProtocolRemote::new(
+			now,
+			session_id,
+			self.logger.clone(),
+			associated_block_id,
+			retry_id,
+		);
+
 		self.logger.debug(format!(
 			"Active local key enabled for stage {:?}? {}",
 			stage,
@@ -365,6 +378,7 @@ where
 			logger: self.logger.clone(),
 			local_key: active_local_key,
 			associated_block_id,
+			retry_id,
 		};
 
 		if let ProtoStageType::Signing { unsigned_proposal_hash } = &stage {
@@ -458,6 +472,16 @@ where
 					DKGMsgStatus::QUEUED
 				};
 				let start_handle = async_proto_params.handle.clone();
+				let retry_id = start_handle.retry_id;
+
+				let mut enqueued_messages = self
+					.keygen_enqueued_messages
+					.lock()
+					.entry(session_id)
+					.or_default()
+					.remove(&retry_id)
+					.unwrap_or_default();
+
 				match GenericAsyncHandler::setup_keygen(async_proto_params, threshold, status) {
 					Ok(meta_handler) => {
 						let logger = self.logger.clone();
@@ -467,6 +491,20 @@ where
 									"Error starting keygen protocol: {err:?}"
 								));
 								return
+							}
+
+							// deliver any enqueued messages
+							while let Some(msg) = enqueued_messages.pop_front() {
+								logger.debug_keygen(format!(
+									"Delivering enqueued message: session={}, retry_id={}",
+									msg.msg.session_id, msg.msg.retry_id
+								));
+
+								if let Err(err) = start_handle.deliver_message(msg) {
+									logger.error_keygen(format!(
+										"Error delivering enqueued message: {err:?}"
+									));
+								}
 							}
 
 							match meta_handler.await {
@@ -1044,7 +1082,7 @@ where
 					// For example, if we are running a 3 node network, with 1-of-2 DKG, it will not
 					// be possible to successfully report the DKG Misbehavior on chain.
 					let max_retries = if t + 1 == n { 0 } else { MAX_KEYGEN_RETRIES };
-					let v = self.keygen_retry_count.load(Ordering::SeqCst);
+					let v = self.keygen_retry_count.load(Ordering::SeqCst) as usize;
 					let should_retry = v < max_retries || max_retries == 0;
 					if keygen_stalled {
 						self.logger.debug(format!(
@@ -1300,7 +1338,9 @@ where
 		let res = match &dkg_msg.msg.payload {
 			DKGMsgPayload::Keygen(_) => {
 				if let Some(rounds) = &rounds {
-					if rounds.session_id == dkg_msg.msg.session_id {
+					if rounds.session_id == dkg_msg.msg.session_id &&
+						rounds.retry_id == dkg_msg.msg.retry_id
+					{
 						if let Err(err) = rounds.deliver_message(dkg_msg) {
 							self.handle_dkg_error(DKGError::CriticalError {
 								reason: err.to_string(),
@@ -1312,7 +1352,9 @@ where
 				}
 
 				if let Some(next_rounds) = next_rounds {
-					if next_rounds.session_id == dkg_msg.msg.session_id {
+					if next_rounds.session_id == dkg_msg.msg.session_id &&
+						next_rounds.retry_id == dkg_msg.msg.retry_id
+					{
 						if let Err(err) = next_rounds.deliver_message(dkg_msg) {
 							self.handle_dkg_error(DKGError::CriticalError {
 								reason: err.to_string(),
@@ -1323,9 +1365,17 @@ where
 					}
 				}
 
-				// TODO: if the message belongs to neither, investigate if we maybe need to enqueue
-				// the message (did someone else's protocol start before ours, and neither of our
-				// rounds are set-up?)
+				// Message belongs to neither. Enqueue it
+				self.logger.debug(format!(
+					"Enqueueing keygen message for later processing: session={}, retry_id={}",
+					dkg_msg.msg.session_id, dkg_msg.msg.retry_id
+				));
+				let mut lock = self.keygen_enqueued_messages.lock();
+				lock.entry(dkg_msg.msg.session_id)
+					.or_default()
+					.entry(dkg_msg.msg.retry_id)
+					.or_default()
+					.push_back(dkg_msg);
 
 				Ok(())
 			},

--- a/dkg-primitives/src/types.rs
+++ b/dkg-primitives/src/types.rs
@@ -53,8 +53,10 @@ pub struct DKGMessage<AuthorityId> {
 	pub recipient_id: Option<AuthorityId>,
 	/// DKG message contents
 	pub payload: DKGMsgPayload,
-	/// Indentifier for the message
+	/// Identifier for the message
 	pub session_id: SessionId,
+	/// For identifying the retry count associated with the protocol
+	pub retry_id: u16,
 	/// enum for active or queued
 	pub status: DKGMsgStatus,
 	/// The round ID


### PR DESCRIPTION
In the spirit of expeditiousness, while #652 is being debugged, we will add message enqueueing and additional checks to keygen messages in order to reduce the number of avenues from which stalling may occur.
