### PR TITLE
Generate multiple signing sets, create signing set IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13469,7 +13469,7 @@ dependencies = [
 [[package]]
 name = "webb-proposals"
 version = "0.5.24"
-source = "git+https://github.com/webb-tools/webb-rs?rev=bb0ab9e#bb0ab9e94b242a6c56fb9f594f9d3a4219e4cbc8"
+source = "git+https://github.com/webb-tools/webb-rs#8dd2e19f98842729ed9c77d4badf8d35b4308e81"
 dependencies = [
  "frame-support",
  "hex",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 <a href="https://www.webb.tools/">
-    
+
 ![Webb Logo](./assets/webb_banner_light.png#gh-light-mode-only)
 ![Webb Logo](./assets/webb_banner_dark.png#gh-dark-mode-only)
   </a>
@@ -29,7 +29,7 @@
     <li><a href="#test">Testing</a></li>
     <li><a href="#contribute">Contributing</a></li>
     <li><a href="#license">License</a></li>
-  </ul>  
+  </ul>
 </details>
 
 <h1 id="start"> Getting Started  🎉 </h1>
@@ -131,3 +131,13 @@ If you have a contribution in mind, please check out our [Contribution Guide](./
 Licensed under <a href="LICENSE">GNU General Public License v3.0</a>.
 
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in this crate by you, as defined in the GNU General Public License v3.0 license, shall be licensed as above, without any additional terms or conditions.
+
+
+## Troubleshooting
+The linking phase may fail due to not finding libgmp (i.e., "could not find library -lgmp") when building on a mac M1. To fix this problem, run:
+
+```bash
+brew install gmp
+# make sure to run the commands below each time when starting a new env, or, append them to .zshrc
+export LIBRARY_PATH=$LIBRARY_PATH:/opt/homebrew/lib
+export INCLUDE_PATH=$INCLUDE_PATH:/opt/homebrew/include

--- a/dkg-gadget/src/async_protocols/mod.rs
+++ b/dkg-gadget/src/async_protocols/mod.rs
@@ -680,6 +680,7 @@ where
 				recipient_id: maybe_recipient_id,
 				payload,
 				session_id: params.session_id,
+				ssid: params.handle.ssid,
 			};
 			if let Err(err) = params.engine.sign_and_send_msg(unsigned_dkg_message) {
 				params

--- a/dkg-gadget/src/async_protocols/sign/handler.rs
+++ b/dkg-gadget/src/async_protocols/sign/handler.rs
@@ -255,6 +255,7 @@ where
 				recipient_id: None,
 				payload,
 				session_id: params.session_id,
+				ssid: params.handle.ssid,
 			};
 
 			params.engine.sign_and_send_msg(unsigned_dkg_message.clone())?;

--- a/dkg-gadget/src/gossip_messages/misbehaviour_report.rs
+++ b/dkg-gadget/src/gossip_messages/misbehaviour_report.rs
@@ -150,6 +150,7 @@ where
 			recipient_id: None,
 			session_id: report.session_id,
 			payload,
+			ssid: 0,
 		};
 		let encoded_dkg_message = message.encode();
 

--- a/dkg-gadget/src/gossip_messages/public_key_gossip.rs
+++ b/dkg-gadget/src/gossip_messages/public_key_gossip.rs
@@ -149,6 +149,7 @@ pub(crate) fn gossip_public_key<GE>(
 			recipient_id: None,
 			session_id: msg.session_id,
 			payload,
+			ssid: 0,
 		};
 		let encoded_dkg_message = message.encode();
 

--- a/dkg-gadget/src/lib.rs
+++ b/dkg-gadget/src/lib.rs
@@ -34,7 +34,7 @@ pub mod keystore;
 
 pub mod gossip_engine;
 mod keygen_manager;
-mod signing_manager;
+pub mod signing_manager;
 // mod meta_async_rounds;
 pub mod db;
 mod metrics;

--- a/dkg-gadget/src/signing_manager/work_manager.rs
+++ b/dkg-gadget/src/signing_manager/work_manager.rs
@@ -399,6 +399,7 @@ fn should_deliver<B: BlockT>(
 ) -> bool {
 	task.handle.session_id == msg.msg.session_id &&
 		task.task_hash == message_task_hash &&
+		task.handle.ssid == msg.msg.ssid &&
 		associated_block_id_acceptable(
 			task.handle.associated_block_id,
 			msg.msg.associated_block_id,

--- a/dkg-primitives/src/types.rs
+++ b/dkg-primitives/src/types.rs
@@ -52,6 +52,8 @@ pub struct DKGMessage<AuthorityId> {
 	pub session_id: SessionId,
 	/// The round ID
 	pub associated_block_id: u64,
+	/// The signing set ID
+	pub ssid: u8,
 }
 
 #[derive(Debug, Clone, Decode, Encode)]

--- a/dkg-test-orchestrator/src/main.rs
+++ b/dkg-test-orchestrator/src/main.rs
@@ -92,11 +92,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 		blocks_per_session,
 	);
 
+	let max_signing_sets_per_proposal = dkg_gadget::signing_manager::MAX_SIGNING_SETS_PER_PROPOSAL;
+
 	// first, spawn the orchestrator/mock-blockchain
-	let orchestrator_task =
-		MockBlockchain::new(config, api.clone(), dummy_api_logger.clone(), blocks_per_session)
-			.await?
-			.execute();
+	let orchestrator_task = MockBlockchain::new(
+		config,
+		api.clone(),
+		dummy_api_logger.clone(),
+		blocks_per_session,
+		max_signing_sets_per_proposal as usize,
+	)
+	.await?
+	.execute();
 	let orchestrator_handle = tokio::task::spawn(orchestrator_task);
 	// give time for the orchestrator to bind
 	tokio::time::sleep(std::time::Duration::from_millis(1000)).await;


### PR DESCRIPTION
In an effort to increase the probability that signing a proposal succeeds in the event a signer drops off in a signing set, we now spawn 2 signing sets per unsigned proposal. Before SigningManagerV2, we did something similar, except, we did so in response to messages going missing. Now that messages are no longer mysteriously dropping, so long as nodes stay online and are non-malicious, we increase the probability that we converge toward signing completion.
